### PR TITLE
Added Networkx graph representation parameter to swmmio.Model

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ pip install swmmio
 ### Basic Usage
 The `swmmio.Model()` class provides the basic endpoint for interfacing with SWMM models. To get started, save a SWMM5 model (.inp) in a directory with its report file (.rpt). A few examples:   
 ```python
-from swmmio import swmmio
+import swmmio
 
 #instantiate a swmmio model object
 mymodel = swmmio.Model('/path/to/directory with swmm files')
@@ -95,7 +95,7 @@ For example, climate change impacts can be investigated by creating a set of mod
 
 ```python
 import os, shutil
-from swmmio import swmmio
+import swmmio
 from swmmio.utils.modify_model import replace_inp_section
 from swmmio.utils.dataframes import create_dataframeINP
 
@@ -129,7 +129,19 @@ while rise <= 5:
 
 ```
 
+### Access Model Network
+The `swmmio.Model` class returns a Networkx MultiDiGraph representation of the model via that `network` parameter:
+```python
 
+#access the model as a Networkx MutliDiGraph
+G = model.network
+
+#iterate through links
+for u, v, key, data in model.network.edges(data=True, keys=True):
+
+        print (key, data['Geom1'])
+        # do stuff with the network
+```  
 
 ### Running Models
 Using the command line tool, individual SWMM5 models can be run by invoking the swmmio module in your shell as such:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ numpy
 pandas
 pyshp
 geojson
+networkx
 # Run dependencies

--- a/swmmio/__init__.py
+++ b/swmmio/__init__.py
@@ -1,0 +1,1 @@
+from .swmmio import *

--- a/swmmio/reporting/serialize.py
+++ b/swmmio/reporting/serialize.py
@@ -5,11 +5,7 @@ from pandas.io.json import json_normalize
 from swmmio.utils import spatial
 from swmmio.graphics import swmm_graphics as sg
 from swmmio.reporting.reporting import FloodReport
-<<<<<<< HEAD
-from swmmio.definitions import *
-=======
 from swmmio.defs.config import *
->>>>>>> master
 import geojson
 
 

--- a/swmmio/swmmio.py
+++ b/swmmio/swmmio.py
@@ -7,6 +7,7 @@ import pandas as pd
 import glob
 import math
 from .utils import spatial
+from .utils import functions
 from .utils import text as txt
 from .utils.dataframes import create_dataframeINP, create_dataframeRPT, get_link_coords
 from .defs.config import *
@@ -60,7 +61,8 @@ class Model(object):
 			self._weirs_df = None
 			self._pumps_df = None
 			self._subcatchments_df = None
-			
+			self._network = None
+
 	def rpt_is_valid(self , verbose=False):
 		"""
 		Return true if the .rpt file exists and has a revision date more
@@ -101,14 +103,18 @@ class Model(object):
 		To be removed in v0.4.0. Use swmmio.reporting.visualize.create_map()
 		'''
 		def wrn():
-			w = "Depreciated. Use swmmio.reporting.visualize.create_map() instead"
+			w = '''to_map is no longer supported! Use
+			swmmio.reporting.visualize.create_map() instead'''
 			warnings.warn(w, DeprecationWarning)
-			return self.nodes().loc[node]
 
 		with warnings.catch_warnings():
 			warnings.simplefilter("always")
 			wrn()
 
+	# def conduits(self):
+	# 	return self.conduits
+
+	# @property
 	def conduits(self):
 
 		"""
@@ -340,6 +346,17 @@ class Model(object):
 		with warnings.catch_warnings():
 			warnings.simplefilter("always")
 			wrn()
+
+	@property
+	def network(self):
+		'''
+		Networkx MultiDiGraph representation of the model
+		'''
+		if self._network is None:
+			G = functions.model_to_networkx(self, drop_cycles=False)
+			self._network = G
+
+		return self._network
 
 
 	def export_to_shapefile(self, shpdir, prj=None):

--- a/swmmio/tests/data/__init__.py
+++ b/swmmio/tests/data/__init__.py
@@ -14,6 +14,7 @@ DATA_PATH = os.path.abspath(os.path.dirname(__file__))
 
 # Test models paths
 MODEL_FULL_FEATURES_PATH = os.path.join(DATA_PATH, 'model_full_features.inp')
+MODEL_FULL_FEATURES__NET_PATH = os.path.join(DATA_PATH, 'model_full_features_network.inp')
 MODEL_BROWARD_COUNTY_PATH = os.path.join(DATA_PATH, 'RUNOFF46_SW5.INP')
 
 #version control test models

--- a/swmmio/tests/data/model_full_features_network.inp
+++ b/swmmio/tests/data/model_full_features_network.inp
@@ -1,0 +1,297 @@
+[TITLE]
+;;Project Title/Notes
+
+[OPTIONS]
+;;Option             Value
+FLOW_UNITS           CFS
+INFILTRATION         HORTON
+FLOW_ROUTING         DYNWAVE
+LINK_OFFSETS         DEPTH
+MIN_SLOPE            0
+ALLOW_PONDING        NO
+SKIP_STEADY_STATE    NO
+
+START_DATE           11/01/2015
+START_TIME           14:00:00
+REPORT_START_DATE    11/01/2015
+REPORT_START_TIME    14:00:00
+END_DATE             11/04/2015
+END_TIME             00:00:00
+SWEEP_START          01/01
+SWEEP_END            12/31
+DRY_DAYS             0
+REPORT_STEP          00:01:00
+WET_STEP             00:05:00
+DRY_STEP             00:05:00
+ROUTING_STEP         0:00:01
+
+INERTIAL_DAMPING     NONE
+NORMAL_FLOW_LIMITED  BOTH
+FORCE_MAIN_EQUATION  H-W
+VARIABLE_STEP        0.75
+LENGTHENING_STEP     0
+MIN_SURFAREA         12.557
+MAX_TRIALS           8
+HEAD_TOLERANCE       0.005
+SYS_FLOW_TOL         5
+LAT_FLOW_TOL         5
+MINIMUM_STEP         0.5
+THREADS              1
+
+[EVAPORATION]
+;;Data Source    Parameters
+;;-------------- ----------------
+CONSTANT         0.0
+DRY_ONLY         NO
+
+[RAINGAGES]
+;;Name           Format    Interval SCF      Source
+;;-------------- --------- ------ ------ ----------
+SCS_24h_Type_I_1in INTENSITY 0:15     1.0      TIMESERIES SCS_24h_Type_I_1in
+
+[SUBCATCHMENTS]
+;;Name           Rain Gage        Outlet           Area     %Imperv  Width    %Slope   CurbLen  SnowPack
+;;-------------- ---------------- ---------------- -------- -------- -------- -------- -------- ----------------
+S1               SCS_24h_Type_I_1in J1               1        100      500      0.5      0
+S2               SCS_24h_Type_I_1in J2               2        100      500      0.5      0
+S3               SCS_24h_Type_I_1in j3               3        100      500      0.5      0
+
+[SUBAREAS]
+;;Subcatchment   N-Imperv   N-Perv     S-Imperv   S-Perv     PctZero    RouteTo    PctRouted
+;;-------------- ---------- ---------- ---------- ---------- ---------- ---------- ----------
+S1               0.01       0.1        0.05       0.05       25         OUTLET
+S2               0.01       0.1        0.05       0.05       25         OUTLET
+S3               0.01       0.1        0.05       0.05       25         OUTLET
+
+[INFILTRATION]
+;;Subcatchment   MaxRate    MinRate    Decay      DryTime    MaxInfil
+;;-------------- ---------- ---------- ---------- ---------- ----------
+S1               3          0.5        4          7          0
+S2               3          0.5        4          7          0
+S3               3          0.5        4          7          0
+
+[JUNCTIONS]
+;;Name           Elevation  MaxDepth   InitDepth  SurDepth   Aponded
+;;-------------- ---------- ---------- ---------- ---------- ----------
+J1               20.728     15         0          0          0
+J3               6.547      15         0          0          0
+1                0          0          0          0          0
+2                0          0          0          0          0
+3                0          0          0          0          0
+4                0          0          0          0          0
+5                0          0          0          0          0
+
+[OUTFALLS]
+;;Name           Elevation  Type       Stage Data       Gated    Route To
+;;-------------- ---------- ---------- ---------------- -------- ----------------
+J4               0          FREE                        NO
+
+[STORAGE]
+;;Name           Elev.    MaxDepth   InitDepth  Shape      Curve Name/Params            N/A      Fevap    Psi      Ksat     IMD
+;;-------------- -------- ---------- ----------- ---------- ---------------------------- -------- --------          -------- --------
+J2               13.392   15         0          FUNCTIONAL 1000      0         0        0        0
+
+[CONDUITS]
+;;Name           From Node        To Node          Length     Roughness  InOffset   OutOffset  InitFlow   MaxFlow
+;;-------------- ---------------- ---------------- ---------- ---------- ---------- ---------- ---------- ----------
+C1:C2            J1               J2               244.63     0.01       0          0          0          0
+C2.1             J2               J3               666        0.01       0          0          0          0         
+1                1                4                400        0.01       0          0          0          0
+2                4                5                400        0.01       0          0          0          0
+3                5                J1               400        0.01       0          0          0          0
+4                3                4                400        0.01       0          0          0          0
+5                2                5                400        0.01       0          0          0          0
+
+[PUMPS]
+;;Name           From Node        To Node          Pump Curve       Status   Sartup Shutoff
+;;-------------- ---------------- ---------------- ---------------- ------ -------- --------
+C2               J2               J3               *                ON       0        0
+
+[WEIRS]
+;;Name           From Node        To Node          Type         CrestHt    Qcoeff     Gated    EndCon   EndCoeff   Surcharge  RoadWidth  RoadSurf
+;;-------------- ---------------- ---------------- ------------ ---------- ---------- -------- -------- ---------- ---------- ---------- ----------
+C3               J3               J4               TRANSVERSE   0          3.33       NO       0        0          NO
+
+[XSECTIONS]
+;;Link           Shape        Geom1            Geom2      Geom3      Geom4      Barrels    Culvert
+;;-------------- ------------ ---------------- ---------- ---------- ---------- ---------- ----------
+C1:C2            CIRCULAR     1                0          0          0          1
+C2.1             CIRCULAR     1                0          0          0          1
+1                CIRCULAR     1                0          0          0          1
+2                CIRCULAR     1                0          0          0          1
+3                CIRCULAR     1                0          0          0          1
+4                CIRCULAR     1                0          0          0          1
+5                CIRCULAR     1                0          0          0          1
+C3               RECT_OPEN    5                1          0          0
+
+[INFLOWS]
+;;Node           Constituent      Time Series      Type     Mfactor  Sfactor  Baseline Pattern
+;;-------------- ---------------- ---------------- -------- -------- -------- -------- --------
+J1               FLOW             ""               FLOW     1.0      1        1
+J3               Flow             ""               FLOW     1.0      1        1
+J2               FLOW             ""               FLOW     1.0      1        1
+
+[DWF]
+;;Node           Constituent      Baseline   Patterns
+;;-------------- ---------------- ---------- ----------
+J1               FLOW             8          "" "" ""
+
+[TIMESERIES]
+;;Name           Date       Time       Value
+;;-------------- ---------- ---------- ----------
+;SCS_24h_Type_I_1in design storm, total rainfall = 1 in, rain units = in/hr.
+SCS_24h_Type_I_1in            0:00       0.0175
+SCS_24h_Type_I_1in            0:15       0.0175
+SCS_24h_Type_I_1in            0:30       0.0175
+SCS_24h_Type_I_1in            0:45       0.0175
+SCS_24h_Type_I_1in            1:00       0.0175
+SCS_24h_Type_I_1in            1:15       0.0175
+SCS_24h_Type_I_1in            1:30       0.0175
+SCS_24h_Type_I_1in            1:45       0.0175
+SCS_24h_Type_I_1in            2:00       0.0205
+SCS_24h_Type_I_1in            2:15       0.0205
+SCS_24h_Type_I_1in            2:30       0.0205
+SCS_24h_Type_I_1in            2:45       0.0205
+SCS_24h_Type_I_1in            3:00       0.0205
+SCS_24h_Type_I_1in            3:15       0.0205
+SCS_24h_Type_I_1in            3:30       0.0205
+SCS_24h_Type_I_1in            3:45       0.0205
+SCS_24h_Type_I_1in            4:00       0.0245
+SCS_24h_Type_I_1in            4:15       0.0245
+SCS_24h_Type_I_1in            4:30       0.0245
+SCS_24h_Type_I_1in            4:45       0.0245
+SCS_24h_Type_I_1in            5:00       0.0245
+SCS_24h_Type_I_1in            5:15       0.0245
+SCS_24h_Type_I_1in            5:30       0.0245
+SCS_24h_Type_I_1in            5:45       0.0245
+SCS_24h_Type_I_1in            6:00       0.031
+SCS_24h_Type_I_1in            6:15       0.031
+SCS_24h_Type_I_1in            6:30       0.031
+SCS_24h_Type_I_1in            6:45       0.031
+SCS_24h_Type_I_1in            7:00       0.038
+SCS_24h_Type_I_1in            7:15       0.038
+SCS_24h_Type_I_1in            7:30       0.038
+SCS_24h_Type_I_1in            7:45       0.038
+SCS_24h_Type_I_1in            8:00       0.05
+SCS_24h_Type_I_1in            8:15       0.05
+SCS_24h_Type_I_1in            8:30       0.07
+SCS_24h_Type_I_1in            8:45       0.07
+SCS_24h_Type_I_1in            9:00       0.098
+SCS_24h_Type_I_1in            9:15       0.098
+SCS_24h_Type_I_1in            9:30       0.236
+SCS_24h_Type_I_1in            9:45       0.612
+SCS_24h_Type_I_1in            10:00      0.136
+SCS_24h_Type_I_1in            10:15      0.136
+SCS_24h_Type_I_1in            10:30      0.082
+SCS_24h_Type_I_1in            10:45      0.082
+SCS_24h_Type_I_1in            11:00      0.06
+SCS_24h_Type_I_1in            11:15      0.06
+SCS_24h_Type_I_1in            11:30      0.06
+SCS_24h_Type_I_1in            11:45      0.052
+SCS_24h_Type_I_1in            12:00      0.048
+SCS_24h_Type_I_1in            12:15      0.048
+SCS_24h_Type_I_1in            12:30      0.042
+SCS_24h_Type_I_1in            12:45      0.042
+SCS_24h_Type_I_1in            13:00      0.042
+SCS_24h_Type_I_1in            13:15      0.042
+SCS_24h_Type_I_1in            13:30      0.038
+SCS_24h_Type_I_1in            13:45      0.038
+SCS_24h_Type_I_1in            14:00      0.0315
+SCS_24h_Type_I_1in            14:15      0.0315
+SCS_24h_Type_I_1in            14:30      0.0315
+SCS_24h_Type_I_1in            14:45      0.0315
+SCS_24h_Type_I_1in            15:00      0.0315
+SCS_24h_Type_I_1in            15:15      0.0315
+SCS_24h_Type_I_1in            15:30      0.0315
+SCS_24h_Type_I_1in            15:45      0.0315
+SCS_24h_Type_I_1in            16:00      0.024
+SCS_24h_Type_I_1in            16:15      0.024
+SCS_24h_Type_I_1in            16:30      0.024
+SCS_24h_Type_I_1in            16:45      0.024
+SCS_24h_Type_I_1in            17:00      0.024
+SCS_24h_Type_I_1in            17:15      0.024
+SCS_24h_Type_I_1in            17:30      0.024
+SCS_24h_Type_I_1in            17:45      0.024
+SCS_24h_Type_I_1in            18:00      0.024
+SCS_24h_Type_I_1in            18:15      0.024
+SCS_24h_Type_I_1in            18:30      0.024
+SCS_24h_Type_I_1in            18:45      0.024
+SCS_24h_Type_I_1in            19:00      0.024
+SCS_24h_Type_I_1in            19:15      0.024
+SCS_24h_Type_I_1in            19:30      0.024
+SCS_24h_Type_I_1in            19:45      0.024
+SCS_24h_Type_I_1in            20:00      0.0185
+SCS_24h_Type_I_1in            20:15      0.0185
+SCS_24h_Type_I_1in            20:30      0.0185
+SCS_24h_Type_I_1in            20:45      0.0185
+SCS_24h_Type_I_1in            21:00      0.0185
+SCS_24h_Type_I_1in            21:15      0.0185
+SCS_24h_Type_I_1in            21:30      0.0185
+SCS_24h_Type_I_1in            21:45      0.0185
+SCS_24h_Type_I_1in            22:00      0.0185
+SCS_24h_Type_I_1in            22:15      0.0185
+SCS_24h_Type_I_1in            22:30      0.0185
+SCS_24h_Type_I_1in            22:45      0.0185
+SCS_24h_Type_I_1in            23:00      0.0185
+SCS_24h_Type_I_1in            23:15      0.0185
+SCS_24h_Type_I_1in            23:30      0.0185
+SCS_24h_Type_I_1in            23:45      0.0185
+SCS_24h_Type_I_1in            24:00      0
+
+[REPORT]
+;;Reporting Options
+INPUT      YES
+CONTROLS   YES
+SUBCATCHMENTS ALL
+NODES ALL
+LINKS ALL
+
+[TAGS]
+
+[MAP]
+DIMENSIONS -100.036 -181.979 708.126 213.879
+Units      Feet
+
+[COORDINATES]
+;;Node           X-Coord            Y-Coord
+;;-------------- ------------------ ------------------
+J1               0.000              0.000
+J3               459.058            -113.145
+1                -77.021            -78.321
+2                -84.988            43.833
+3                -18.600            -71.239
+4                -67.284            -37.603
+5                -56.662            15.507
+J4               671.391            -163.985
+J2               238.750            -53.332
+
+[VERTICES]
+;;Link           X-Coord            Y-Coord
+;;-------------- ------------------ ------------------
+C2.1             295.636            -159.756
+C2.1             360.253            -181.886
+4                -23.911            -51.766
+5                -85.873            19.933
+
+[Polygons]
+;;Subcatchment   X-Coord            Y-Coord
+;;-------------- ------------------ ------------------
+S1               110.154            195.885
+S1               110.154            47.351
+S1               -56.323            42.367
+S1               -63.301            181.928
+S1               110.154            195.885
+S2               394.261            131.088
+S2               410.211            -20.436
+S2               245.728            -19.439
+S2               235.759            110.154
+S2               394.261            131.088
+S3               660.425            55.326
+S3               657.435            -104.173
+S3               519.867            -96.198
+S3               509.898            50.342
+S3               660.425            55.326
+
+[SYMBOLS]
+;;Gage           X-Coord            Y-Coord
+;;-------------- ------------------ ------------------

--- a/swmmio/tests/test_dataframes.py
+++ b/swmmio/tests/test_dataframes.py
@@ -1,6 +1,7 @@
-from swmmio.tests.data import (MODEL_FULL_FEATURES_PATH,
+from swmmio.tests.data import (MODEL_FULL_FEATURES_PATH, MODEL_FULL_FEATURES__NET_PATH,
                                MODEL_BROWARD_COUNTY_PATH, MODEL_XSECTION_ALT_01)
 from swmmio import swmmio
+
 
 def test_conduits_dataframe():
 
@@ -22,3 +23,12 @@ def test_nodes_dataframe():
     assert(nodes.loc['dummy_node3', 'X'] == -4205.457)
     assert(nodes.loc['dummy_node4', 'MaxDepth'] == 12.59314)
     assert(nodes.loc['dummy_node5', 'PondedArea'] == 73511)
+
+def test_model_to_networkx():
+
+    m = swmmio.Model(MODEL_FULL_FEATURES__NET_PATH)
+    G = m.network
+
+    assert(G['J2']['J3']['C2.1']['Length'] == 666)
+    assert(G['J1']['J2']['C1:C2']['Length'] == 244.63)
+    assert(round(G.node['J2']['InvertElev'], 3) == 13.392)


### PR DESCRIPTION
##
Adds `network` parameter to `swmmio.Model` returning a Networkx MutliDiGraph representation of the hydraulic model. Doesn't include subcatchment connectivity yet.

```python 
import swmmio
model = swmmio.Model('path/to/model.inp')

#access the model as a Networkx MutliDiGraph
G = model.network

#iterate through links 
for u, v, key, data in model.network.edges(data=True, keys=True):
        
        print (key, data['Geom1'])
        
        ...
```

Closes #40 