### PR TITLE
Attempt to address issue #103 bug

### DIFF
--- a/swmmio/defs/__init__.py
+++ b/swmmio/defs/__init__.py
@@ -15,6 +15,7 @@ with open(_HEADERS_YAML, 'r') as f:
 
 INP_OBJECTS = normalize_inp_config(_inp_sections_conf_raw['inp_file_objects'])
 RPT_OBJECTS = normalize_inp_config(HEADERS_YML['rpt_sections'])
+SWMM5_VERSION = HEADERS_YML['swmm5_version']
 INP_SECTION_TAGS = _inp_sections_conf_raw['inp_section_tags']
 INFILTRATION_COLS = _inp_sections_conf_raw['infiltration_cols']
 COMPOSITE_OBJECTS = HEADERS_YML['composite']

--- a/swmmio/defs/section_headers.yml
+++ b/swmmio/defs/section_headers.yml
@@ -12,7 +12,6 @@ conduits:
   inp_sections: ['[CONDUITS]', '[XSECTIONS]']
   rpt_sections: [Link Flow Summary]
 
-
 rpt_sections:
   Cross Section Summary:
     - Name
@@ -134,6 +133,23 @@ rpt_sections:
     - RainGage
     - Outlet
 
+swmm5_version:
+  # patch
+  13:
+    rpt_sections:
+      Subcatchment Runoff Summary:
+        - Name
+        - TotalPrecip
+        - TotalRunon
+        - TotalEvap
+        - TotalInfil
+        - ImpervRunoff
+        - PervRunoff
+        - TotalRunoffIn
+        - TotalRunoffMG
+        - PeakRunoff
+        - RunoffCoeff
+        
 composite:
   nodes:
     inp_sections: [junctions, outfalls, storage]

--- a/swmmio/defs/section_headers.yml
+++ b/swmmio/defs/section_headers.yml
@@ -134,8 +134,7 @@ rpt_sections:
     - Outlet
 
 swmm5_version:
-  # patch
-  13:
+  1.13:
     rpt_sections:
       Subcatchment Runoff Summary:
         - Name

--- a/swmmio/elements.py
+++ b/swmmio/elements.py
@@ -117,14 +117,13 @@ class ModelSection(object):
             # add conduit coordinates
             xys = df.apply(lambda r: get_link_coords(r, self.inp.coordinates, self.inp.vertices), axis=1)
             df = df.assign(coords=xys.map(lambda x: x[0]))
-
             # make inlet/outlet node IDs string type
             df.InletNode = df.InletNode.astype(str)
             df.OutletNode = df.OutletNode.astype(str)
 
         elif self.geomtype == 'polygon':
             p = self.inp.polygons
-
+            p.index = p.index.map(str)
             # take stacked coordinates and orient in list of tuples,
             xys = p.groupby(by=p.index).apply(lambda r: [(xy['X'], xy['Y']) for ix, xy in r.iterrows()])
             # copy the first point to the last position

--- a/swmmio/elements.py
+++ b/swmmio/elements.py
@@ -105,7 +105,7 @@ class ModelSection(object):
         # if there is an RPT available, grab relevant sections
         if self.rpt:
             for rpt_sect in self.rpt_sections:
-                df = df.join(dataframe_from_rpt(self.rpt.path, rpt_sect))
+                df = df.join(dataframe_from_rpt(self.rpt.path, rpt_sect, swmm_version=self.rpt.swmm_version))
 
         # add coordinates
         if self.geomtype == 'point':

--- a/swmmio/tests/data/Example1.inp
+++ b/swmmio/tests/data/Example1.inp
@@ -1,0 +1,338 @@
+[TITLE]
+Example 1
+
+
+[OPTIONS]
+;;Options            Value
+;;------------------ ------------
+FLOW_UNITS           CFS
+INFILTRATION         HORTON
+FLOW_ROUTING         KINWAVE
+LINK_OFFSETS         DEPTH
+MIN_SLOPE            0
+ALLOW_PONDING        NO
+SKIP_STEADY_STATE    NO
+START_DATE           01/01/1998
+START_TIME           00:00:00
+REPORT_START_DATE    01/01/1998
+REPORT_START_TIME    00:00:00
+END_DATE             01/02/1998
+END_TIME             12:00:00
+SWEEP_START          1/1
+SWEEP_END            12/31
+DRY_DAYS             5
+REPORT_STEP          01:00:00
+WET_STEP             00:15:00
+DRY_STEP             01:00:00
+ROUTING_STEP         60
+INERTIAL_DAMPING     PARTIAL
+NORMAL_FLOW_LIMITED  BOTH
+FORCE_MAIN_EQUATION  H-W
+VARIABLE_STEP        0.75
+LENGTHENING_STEP     0
+MIN_SURFAREA         0
+MAX_TRIALS           0
+HEAD_TOLERANCE       0
+SYS_FLOW_TOL         5
+LAT_FLOW_TOL         5
+MINIMUM_STEP         0.5
+THREADS              1
+
+[EVAPORATION]
+;;Type          Parameters
+;;------------- ----------
+CONSTANT     0.0
+DRY_ONLY     NO
+
+[RAINGAGES]
+;;               Rain      Time   Snow   Data      
+;;Name           Type      Intrvl Catch  Source    
+;;-------------- --------- ------ ------ ----------
+RG1              INTENSITY 1:00   1.0    TIMESERIES TS1             
+
+[SUBCATCHMENTS]
+;;                                                 Total    Pcnt.             Pcnt.    Curb     Snow    
+;;Name           Raingage         Outlet           Area     Imperv   Width    Slope    Length   Pack    
+;;-------------- ---------------- ---------------- -------- -------- -------- -------- -------- --------
+1                RG1              9                10       50       500      0.01     0                        
+2                RG1              10               10       50       500      0.01     0                        
+3                RG1              13               5        50       500      0.01     0                        
+4                RG1              22               5        50       500      0.01     0                        
+5                RG1              15               15       50       500      0.01     0                        
+6                RG1              23               12       10       500      0.01     0                        
+7                RG1              19               4        10       500      0.01     0                        
+8                RG1              18               10       10       500      0.01     0                        
+
+[SUBAREAS]
+;;Subcatchment   N-Imperv   N-Perv     S-Imperv   S-Perv     PctZero    RouteTo    PctRouted 
+;;-------------- ---------- ---------- ---------- ---------- ---------- ---------- ----------
+1                0.001      0.10       0.05       0.05       25         OUTLET    
+2                0.001      0.10       0.05       0.05       25         OUTLET    
+3                0.001      0.10       0.05       0.05       25         OUTLET    
+4                0.001      0.10       0.05       0.05       25         OUTLET    
+5                0.001      0.10       0.05       0.05       25         OUTLET    
+6                0.001      0.10       0.05       0.05       25         OUTLET    
+7                0.001      0.10       0.05       0.05       25         OUTLET    
+8                0.001      0.10       0.05       0.05       25         OUTLET    
+
+[INFILTRATION]
+;;Subcatchment   MaxRate    MinRate    Decay      DryTime    MaxInfil  
+;;-------------- ---------- ---------- ---------- ---------- ----------
+1                0.35       0.25       4.14       0.50       0         
+2                0.7        0.3        4.14       0.50       0         
+3                0.7        0.3        4.14       0.50       0         
+4                0.7        0.3        4.14       0.50       0         
+5                0.7        0.3        4.14       0.50       0         
+6                0.7        0.3        4.14       0.50       0         
+7                0.7        0.3        4.14       0.50       0         
+8                0.7        0.3        4.14       0.50       0         
+
+[JUNCTIONS]
+;;               Invert     Max.       Init.      Surcharge  Ponded    
+;;Name           Elev.      Depth      Depth      Depth      Area      
+;;-------------- ---------- ---------- ---------- ---------- ----------
+10               995        3          0          0          0         
+13               995        3          0          0          0         
+14               990        3          0          0          0         
+15               987        3          0          0          0         
+16               985        3          0          0          0         
+17               980        3          0          0          0         
+19               1010       3          0          0          0         
+20               1005       3          0          0          0         
+21               990        3          0          0          0         
+22               987        3          0          0          0         
+23               990        3          0          0          0         
+24               984        3          0          0          0         
+9                1000       3          0          0          0         
+
+[OUTFALLS]
+;;               Invert     Outfall      Stage/Table      Tide
+;;Name           Elev.      Type         Time Series      Gate Route To        
+;;-------------- ---------- ------------ ---------------- ---- ----------------
+18               975        FREE                          NO                   
+
+[CONDUITS]
+;;               Inlet            Outlet                      Manning    Inlet      Outlet     Init.      Max.      
+;;Name           Node             Node             Length     N          Offset     Offset     Flow       Flow      
+;;-------------- ---------------- ---------------- ---------- ---------- ---------- ---------- ---------- ----------
+1                9                10               400        0.01       0          0          0          0         
+10               17               18               400        0.01       0          0          0          0         
+11               13               14               400        0.01       0          0          0          0         
+12               14               15               400        0.01       0          0          0          0         
+13               15               16               400        0.01       0          0          0          0         
+14               23               24               400        0.01       0          0          0          0         
+15               16               24               100        0.01       0          0          0          0         
+16               24               17               400        0.01       0          0          0          0         
+4                19               20               200        0.01       0          0          0          0         
+5                20               21               200        0.01       0          0          0          0         
+6                10               21               400        0.01       0          1          0          0         
+7                21               22               300        0.01       1          1          0          0         
+8                22               16               300        0.01       0          0          0          0         
+
+[XSECTIONS]
+;;Link           Shape        Geom1            Geom2      Geom3      Geom4      Barrels   
+;;-------------- ------------ ---------------- ---------- ---------- ---------- ----------
+1                CIRCULAR     1.5              0          0          0          1                    
+10               CIRCULAR     2                0          0          0          1                    
+11               CIRCULAR     1.5              0          0          0          1                    
+12               CIRCULAR     1.5              0          0          0          1                    
+13               CIRCULAR     1.5              0          0          0          1                    
+14               CIRCULAR     1                0          0          0          1                    
+15               CIRCULAR     2                0          0          0          1                    
+16               CIRCULAR     2                0          0          0          1                    
+4                CIRCULAR     1                0          0          0          1                    
+5                CIRCULAR     1                0          0          0          1                    
+6                CIRCULAR     1                0          0          0          1                    
+7                CIRCULAR     2                0          0          0          1                    
+8                CIRCULAR     2                0          0          0          1                    
+
+[LOSSES]
+;;Link           Inlet      Outlet     Average    Flap Gate  SeepageRate
+;;-------------- ---------- ---------- ---------- ---------- ----------
+
+[POLLUTANTS]
+;;               Mass   Rain       GW         I&I        Decay      Snow  Co-Pollut.       Co-Pollut. DWF        Init.
+;;Name           Units  Concen.    Concen.    Concen.    Coeff.     Only  Name             Fraction   Concen.    Concen.
+;;-------------- ------ ---------- ---------- ---------- ---------- ----- ---------------- ---------- ---------- ----------
+Lead             UG/L   0.0        0.0        0          0.0        NO    TSS              0.2        0          0         
+TSS              MG/L   0.0        0.0        0          0.0        NO    *                0.0        0          0         
+
+[LANDUSES]
+;;               Cleaning   Fraction   Last      
+;;Name           Interval   Available  Cleaned   
+;;-------------- ---------- ---------- ----------
+Residential      0          0          0         
+Undeveloped      0          0          0         
+
+[COVERAGES]
+;;Subcatchment   Land Use         Percent   
+;;-------------- ---------------- ----------
+1                Residential      100.00
+2                Residential      50.00
+2                Undeveloped      50.00
+3                Residential      100.00
+4                Residential      50.00
+4                Undeveloped      50.00
+5                Residential      100.00
+6                Undeveloped      100.00
+7                Undeveloped      100.00
+8                Undeveloped      100.00
+
+[LOADINGS]
+;;Subcatchment   Pollutant        Loading   
+;;-------------- ---------------- ----------
+
+[BUILDUP]
+;;LandUse        Pollutant        Function   Coeff1     Coeff2     Coeff3     Normalizer
+;;-------------- ---------------- ---------- ---------- ---------- ---------- ----------
+Residential      Lead             NONE       0          0          0          AREA      
+Residential      TSS              SAT        50         0          2          AREA      
+Undeveloped      Lead             NONE       0          0          0          AREA      
+Undeveloped      TSS              SAT        100        0          3          AREA      
+
+[WASHOFF]
+;;                                                                 Cleaning   BMP       
+;;Land Use       Pollutant        Function   Coeff1     Coeff2     Effic.     Effic.    
+;;-------------- ---------------- ---------- ---------- ---------- ---------- ----------
+Residential      Lead             EMC        0          0          0          0         
+Residential      TSS              EXP        0.1        1          0          0         
+Undeveloped      Lead             EMC        0          0          0          0         
+Undeveloped      TSS              EXP        0.1        0.7        0          0         
+
+[TIMESERIES]
+;;Name           Date       Time       Value     
+;;-------------- ---------- ---------- ----------
+;RAINFALL
+TS1                         0:00       0.0       
+TS1                         1:00       0.25      
+TS1                         2:00       0.5       
+TS1                         3:00       0.8       
+TS1                         4:00       0.4       
+TS1                         5:00       0.1       
+TS1                         6:00       0.0       
+TS1                         27:00      0.0       
+TS1                         28:00      0.4       
+TS1                         29:00      0.2       
+TS1                         30:00      0.0       
+
+[REPORT]
+INPUT      NO
+CONTROLS   NO
+SUBCATCHMENTS ALL
+NODES ALL
+LINKS ALL
+
+[TAGS]
+
+[MAP]
+DIMENSIONS       -188.4225        -154.7365        9514.7325        10196.8465      
+UNITS            None
+
+[COORDINATES]
+;;Node           X-Coord          Y-Coord         
+;;-------------- ---------------- ----------------
+10               4105.26          6947.37         
+13               2336.84          4357.89         
+14               3157.89          4294.74         
+15               3221.05          3242.11         
+16               4821.05          3326.32         
+17               6252.63          2147.37         
+19               7768.42          6736.84         
+20               5957.89          6589.47         
+21               4926.32          6105.26         
+22               4421.05          4715.79         
+23               6484.21          3978.95         
+24               5389.47          3031.58         
+9                4042.11          9600            
+18               6631.58          505.26          
+
+[VERTICES]
+;;Link           X-Coord          Y-Coord         
+;;-------------- ---------------- ----------------
+10               6673.68          1368.42         
+
+[POLYGONS]
+;;Subcatchment   X-Coord          Y-Coord         
+;;-------------- ---------------- ----------------
+1                3936.84          6905.26         
+1                3494.74          6252.63         
+1                273.68           6336.84         
+1                252.63           8526.32         
+1                463.16           9200            
+1                1157.89          9726.32         
+1                4000             9705.26         
+2                7600             9663.16         
+2                7705.26          6736.84         
+2                5915.79          6694.74         
+2                4926.32          6294.74         
+2                4189.47          7200            
+2                4126.32          9621.05         
+3                2357.89          6021.05         
+3                2400             4336.84         
+3                3031.58          4252.63         
+3                2989.47          3389.47         
+3                315.79           3410.53         
+3                294.74           6000            
+4                3473.68          6105.26         
+4                3915.79          6421.05         
+4                4168.42          6694.74         
+4                4463.16          6463.16         
+4                4821.05          6063.16         
+4                4400             5263.16         
+4                4357.89          4442.11         
+4                4547.37          3705.26         
+4                4000             3431.58         
+4                3326.32          3368.42         
+4                3242.11          3536.84         
+4                3136.84          5157.89         
+4                2589.47          5178.95         
+4                2589.47          6063.16         
+4                3284.21          6063.16         
+4                3705.26          6231.58         
+4                4126.32          6715.79         
+5                2568.42          3200            
+5                4905.26          3136.84         
+5                5221.05          2842.11         
+5                5747.37          2421.05         
+5                6463.16          1578.95         
+5                6610.53          968.42          
+5                6589.47          505.26          
+5                1305.26          484.21          
+5                968.42           336.84          
+5                315.79           778.95          
+5                315.79           3115.79         
+6                9052.63          4147.37         
+6                7894.74          4189.47         
+6                6442.11          4105.26         
+6                5915.79          3642.11         
+6                5326.32          3221.05         
+6                4631.58          4231.58         
+6                4568.42          5010.53         
+6                4884.21          5768.42         
+6                5368.42          6294.74         
+6                6042.11          6568.42         
+6                8968.42          6526.32         
+7                8736.84          9642.11         
+7                9010.53          9389.47         
+7                9010.53          8631.58         
+7                9052.63          6778.95         
+7                7789.47          6800            
+7                7726.32          9642.11         
+8                9073.68          2063.16         
+8                9052.63          778.95          
+8                8505.26          336.84          
+8                7431.58          315.79          
+8                7410.53          484.21          
+8                6842.11          505.26          
+8                6842.11          589.47          
+8                6821.05          1178.95         
+8                6547.37          1831.58         
+8                6147.37          2378.95         
+8                5600             3073.68         
+8                6589.47          3894.74         
+8                8863.16          3978.95         
+
+[SYMBOLS]
+;;Gage           X-Coord          Y-Coord         
+;;-------------- ---------------- ----------------
+RG1              10084.21         8210.53         

--- a/swmmio/tests/data/Example1.rpt
+++ b/swmmio/tests/data/Example1.rpt
@@ -1,0 +1,292 @@
+
+  EPA STORM WATER MANAGEMENT MODEL - VERSION 5.1 (Build 5.1.012)
+  --------------------------------------------------------------
+
+  Example 1 
+  
+  
+  *********************************************************
+  NOTE: The summary statistics displayed in this report are
+  based on results found at every computational time step,  
+  not just on results from each reporting time step.
+  *********************************************************
+  
+  ****************
+  Analysis Options
+  ****************
+  Flow Units ............... CFS
+  Process Models:
+    Rainfall/Runoff ........ YES
+    RDII ................... NO
+    Snowmelt ............... NO
+    Groundwater ............ NO
+    Flow Routing ........... YES
+    Ponding Allowed ........ NO
+    Water Quality .......... YES
+  Infiltration Method ...... HORTON
+  Flow Routing Method ...... KINWAVE
+  Starting Date ............ 01/01/1998 00:00:00
+  Ending Date .............. 01/02/1998 12:00:00
+  Antecedent Dry Days ...... 5.0
+  Report Time Step ......... 01:00:00
+  Wet Time Step ............ 00:15:00
+  Dry Time Step ............ 01:00:00
+  Routing Time Step ........ 60.00 sec
+  
+  
+  **************************        Volume         Depth
+  Runoff Quantity Continuity     acre-feet        inches
+  **************************     ---------       -------
+  Total Precipitation ......        15.679         2.650
+  Evaporation Loss .........         0.000         0.000
+  Infiltration Loss ........         9.346         1.580
+  Surface Runoff ...........         6.295         1.064
+  Final Storage ............         0.081         0.014
+  Continuity Error (%) .....        -0.272
+  
+  
+  **************************          Lead           TSS
+  Runoff Quality Continuity            lbs           lbs
+  **************************    ----------    ----------
+  Initial Buildup ..........         0.000      3433.036
+  Surface Buildup ..........         0.086       312.924
+  Wet Deposition ...........         0.000         0.000
+  Sweeping Removal .........         0.000         0.000
+  Infiltration Loss ........         0.000         0.000
+  BMP Removal ..............         0.000         0.000
+  Surface Runoff ...........         0.086       431.367
+  Remaining Buildup ........         0.000      3314.593
+  Continuity Error (%) .....         0.000         0.000
+  
+  
+  **************************        Volume        Volume
+  Flow Routing Continuity        acre-feet      10^6 gal
+  **************************     ---------     ---------
+  Dry Weather Inflow .......         0.000         0.000
+  Wet Weather Inflow .......         6.295         2.051
+  Groundwater Inflow .......         0.000         0.000
+  RDII Inflow ..............         0.000         0.000
+  External Inflow ..........         0.000         0.000
+  External Outflow .........         5.874         1.914
+  Flooding Loss ............         0.415         0.135
+  Evaporation Loss .........         0.000         0.000
+  Exfiltration Loss ........         0.000         0.000
+  Initial Stored Volume ....         0.000         0.000
+  Final Stored Volume ......         0.000         0.000
+  Continuity Error (%) .....         0.101
+  
+  
+  **************************          Lead           TSS
+  Quality Routing Continuity           lbs           lbs
+  **************************    ----------    ----------
+  Dry Weather Inflow .......         0.000         0.000
+  Wet Weather Inflow .......         0.086       431.367
+  Groundwater Inflow .......         0.000         0.000
+  RDII Inflow ..............         0.000         0.000
+  External Inflow ..........         0.000         0.000
+  External Outflow .........         0.082       409.791
+  Flooding Loss ............         0.004        22.239
+  Exfiltration Loss ........         0.000         0.000
+  Mass Reacted .............         0.000         0.000
+  Initial Stored Mass ......         0.000         0.000
+  Final Stored Mass ........         0.000         0.000
+  Continuity Error (%) .....        -0.154        -0.154
+  
+  
+  ********************************
+  Highest Flow Instability Indexes
+  ********************************
+  Link 15 (1)
+  
+  
+  *************************
+  Routing Time Step Summary
+  *************************
+  Minimum Time Step           :    60.00 sec
+  Average Time Step           :    60.00 sec
+  Maximum Time Step           :    60.00 sec
+  Percent in Steady State     :     0.00
+  Average Iterations per Step :     1.49
+  Percent Not Converging      :     0.00
+  
+  
+  ***************************
+  Subcatchment Runoff Summary
+  ***************************
+  
+  --------------------------------------------------------------------------------------------------------
+                            Total      Total      Total      Total      Total       Total     Peak  Runoff
+                           Precip      Runon       Evap      Infil     Runoff      Runoff   Runoff   Coeff
+  Subcatchment                 in         in         in         in         in    10^6 gal      CFS
+  --------------------------------------------------------------------------------------------------------
+  1                          2.65       0.00       0.00       1.16       1.48        0.40     4.66   0.559
+  2                          2.65       0.00       0.00       1.21       1.43        0.39     4.52   0.539
+  3                          2.65       0.00       0.00       1.16       1.49        0.20     2.45   0.561
+  4                          2.65       0.00       0.00       1.16       1.49        0.20     2.45   0.561
+  5                          2.65       0.00       0.00       1.24       1.40        0.57     6.56   0.528
+  6                          2.65       0.00       0.00       2.27       0.38        0.12     1.50   0.143
+  7                          2.65       0.00       0.00       2.14       0.51        0.06     0.79   0.194
+  8                          2.65       0.00       0.00       2.25       0.40        0.11     1.33   0.150
+  
+  
+  ****************************
+  Subcatchment Washoff Summary
+  ****************************
+  
+  ------------------------------------------------
+                                Lead           TSS
+  Subcatchment                   lbs           lbs
+  ------------------------------------------------
+  1                            0.010        50.074
+  2                            0.018        90.586
+  3                            0.005        25.144
+  4                            0.009        46.097
+  5                            0.014        71.172
+  6                            0.013        65.843
+  7                            0.005        26.025
+  8                            0.011        56.427
+  ------------------------------------------------
+  System                       0.086       431.367
+  
+  
+  ******************
+  Node Depth Summary
+  ******************
+  
+  ---------------------------------------------------------------------------------
+                                 Average  Maximum  Maximum  Time of Max    Reported
+                                   Depth    Depth      HGL   Occurrence   Max Depth
+  Node                 Type         Feet     Feet     Feet  days hr:min        Feet
+  ---------------------------------------------------------------------------------
+  10                   JUNCTION     0.32     3.00   998.00     0  02:17        3.00
+  13                   JUNCTION     0.06     0.41   995.41     0  04:01        0.41
+  14                   JUNCTION     0.06     0.46   990.46     0  04:01        0.46
+  15                   JUNCTION     0.15     1.15   988.15     0  04:01        1.15
+  16                   JUNCTION     0.17     1.15   986.15     0  04:01        1.14
+  17                   JUNCTION     0.18     1.14   981.14     0  04:02        1.14
+  19                   JUNCTION     0.03     0.22  1010.22     0  04:01        0.22
+  20                   JUNCTION     0.03     0.22  1005.22     0  04:01        0.22
+  21                   JUNCTION     1.16     2.00   992.00     0  02:55        2.00
+  22                   JUNCTION     1.11     1.58   988.58     0  04:02        1.58
+  23                   JUNCTION     0.05     0.35   990.35     0  04:01        0.35
+  24                   JUNCTION     0.18     1.14   985.14     0  04:01        1.14
+  9                    JUNCTION     0.09     0.57  1000.57     0  04:01        0.57
+  18                   OUTFALL      0.17     1.07   976.07     0  04:02        1.06
+  
+  
+  *******************
+  Node Inflow Summary
+  *******************
+  
+  -------------------------------------------------------------------------------------------------
+                                  Maximum  Maximum                  Lateral       Total        Flow
+                                  Lateral    Total  Time of Max      Inflow      Inflow     Balance
+                                   Inflow   Inflow   Occurrence      Volume      Volume       Error
+  Node                 Type           CFS      CFS  days hr:min    10^6 gal    10^6 gal     Percent
+  -------------------------------------------------------------------------------------------------
+  10                   JUNCTION      4.52     9.17     0  04:01       0.388        0.79      -0.000
+  13                   JUNCTION      2.45     2.45     0  04:01       0.202       0.202       0.000
+  14                   JUNCTION      0.00     2.44     0  04:01           0       0.202       0.000
+  15                   JUNCTION      6.56     9.00     0  04:01        0.57       0.771       0.000
+  16                   JUNCTION      0.00    16.83     0  04:01           0        1.69       0.000
+  17                   JUNCTION      0.00    18.31     0  04:02           0        1.81       0.000
+  19                   JUNCTION      0.79     0.79     0  04:01      0.0558      0.0558       0.000
+  20                   JUNCTION      0.00     0.79     0  04:01           0      0.0558       0.000
+  21                   JUNCTION      0.00     5.42     0  04:02           0       0.714       0.000
+  22                   JUNCTION      2.45     7.86     0  04:01       0.202       0.915       0.000
+  23                   JUNCTION      1.50     1.50     0  04:01       0.124       0.124       0.000
+  24                   JUNCTION      0.00    18.31     0  04:01           0        1.81       0.000
+  9                    JUNCTION      4.66     4.66     0  04:01       0.402       0.402       0.000
+  18                   OUTFALL       1.33    19.58     0  04:01       0.108        1.91       0.000
+  
+  
+  *********************
+  Node Flooding Summary
+  *********************
+  
+  Flooding refers to all water that overflows a node, whether it ponds or not.
+  --------------------------------------------------------------------------
+                                                             Total   Maximum
+                                 Maximum   Time of Max       Flood    Ponded
+                        Hours       Rate    Occurrence      Volume    Volume
+  Node                 Flooded       CFS   days hr:min    10^6 gal  1000 ft3
+  --------------------------------------------------------------------------
+  10                      2.82      4.53      0  04:01       0.135     0.000
+  
+  
+  ***********************
+  Outfall Loading Summary
+  ***********************
+  
+  ---------------------------------------------------------------------------------------
+                         Flow       Avg       Max       Total         Total         Total
+                         Freq      Flow      Flow      Volume          Lead           TSS
+  Outfall Node           Pcnt       CFS       CFS    10^6 gal           lbs           lbs
+  ---------------------------------------------------------------------------------------
+  18                    72.87      2.71     19.58       1.914         0.082       409.791
+  ---------------------------------------------------------------------------------------
+  System                72.87      2.71     19.58       1.914         0.082       409.791
+  
+  
+  ********************
+  Link Flow Summary
+  ********************
+  
+  -----------------------------------------------------------------------------
+                                 Maximum  Time of Max   Maximum    Max/    Max/
+                                  |Flow|   Occurrence   |Veloc|    Full    Full
+  Link                 Type          CFS  days hr:min    ft/sec    Flow   Depth
+  -----------------------------------------------------------------------------
+  1                    CONDUIT      4.65     0  04:01      7.60    0.30    0.38
+  10                   CONDUIT     18.28     0  04:02     10.75    0.56    0.53
+  11                   CONDUIT      2.44     0  04:01      6.36    0.16    0.27
+  12                   CONDUIT      2.44     0  04:02      5.30    0.21    0.31
+  13                   CONDUIT      8.98     0  04:01      6.24    0.93    0.76
+  14                   CONDUIT      1.49     0  04:02      6.12    0.26    0.35
+  15                   CONDUIT     16.82     0  04:01      9.67    0.57    0.54
+  16                   CONDUIT     18.31     0  04:02      9.87    0.62    0.57
+  4                    CONDUIT      0.79     0  04:01      6.10    0.11    0.22
+  5                    CONDUIT      0.79     0  04:02      9.00    0.06    0.17
+  6                    CONDUIT      4.93     0  02:53      7.01    1.06    1.00
+  7                    CONDUIT      5.42     0  04:02      7.19    0.18    0.29
+  8                    CONDUIT      7.85     0  04:01      6.84    0.33    0.39
+  
+  
+  *************************
+  Conduit Surcharge Summary
+  *************************
+  
+  ----------------------------------------------------------------------------
+                                                           Hours        Hours 
+                         --------- Hours Full --------   Above Full   Capacity
+  Conduit                Both Ends  Upstream  Dnstream   Normal Flow   Limited
+  ----------------------------------------------------------------------------
+  6                           2.80      2.80      2.80      2.80         2.80
+  
+  
+  ***************************
+  Link Pollutant Load Summary
+  ***************************
+  
+  ------------------------------------------------
+                                Lead           TSS
+  Link                           lbs           lbs
+  ------------------------------------------------
+  1                            0.010        50.061
+  10                           0.071       353.364
+  11                           0.005        25.127
+  12                           0.005        25.112
+  13                           0.019        96.264
+  14                           0.013        65.740
+  15                           0.058       287.513
+  16                           0.071       353.281
+  4                            0.005        25.990
+  5                            0.005        25.983
+  6                            0.024       119.073
+  7                            0.029       145.055
+  8                            0.038       191.152
+  
+
+  Analysis begun on:  Thu Sep 24 10:19:56 2020
+  Analysis ended on:  Thu Sep 24 10:19:56 2020
+  Total elapsed time: < 1 sec

--- a/swmmio/tests/data/Example1b.inp
+++ b/swmmio/tests/data/Example1b.inp
@@ -1,0 +1,339 @@
+[TITLE]
+Example 1
+
+
+[OPTIONS]
+;;Options            Value
+;;------------------ ------------
+FLOW_UNITS           CFS
+INFILTRATION         HORTON
+FLOW_ROUTING         KINWAVE
+LINK_OFFSETS         DEPTH
+MIN_SLOPE            0
+ALLOW_PONDING        NO
+SKIP_STEADY_STATE    NO
+START_DATE           01/01/1998
+START_TIME           00:00:00
+REPORT_START_DATE    01/01/1998
+REPORT_START_TIME    00:00:00
+END_DATE             01/02/1998
+END_TIME             12:00:00
+SWEEP_START          1/1
+SWEEP_END            12/31
+DRY_DAYS             5
+REPORT_STEP          01:00:00
+WET_STEP             00:15:00
+DRY_STEP             01:00:00
+ROUTING_STEP         60
+RULE_STEP            00:00:00
+INERTIAL_DAMPING     PARTIAL
+NORMAL_FLOW_LIMITED  BOTH
+FORCE_MAIN_EQUATION  H-W
+VARIABLE_STEP        0.75
+LENGTHENING_STEP     0
+MIN_SURFAREA         0
+MAX_TRIALS           0
+HEAD_TOLERANCE       0
+SYS_FLOW_TOL         5
+LAT_FLOW_TOL         5
+MINIMUM_STEP         0.5
+THREADS              1
+
+[EVAPORATION]
+;;Type          Parameters
+;;------------- ----------
+CONSTANT     0.0
+DRY_ONLY     NO
+
+[RAINGAGES]
+;;               Rain      Time   Snow   Data      
+;;Name           Type      Intrvl Catch  Source    
+;;-------------- --------- ------ ------ ----------
+RG1              INTENSITY 1:00   1.0    TIMESERIES TS1             
+
+[SUBCATCHMENTS]
+;;                                                 Total    Pcnt.             Pcnt.    Curb     Snow    
+;;Name           Raingage         Outlet           Area     Imperv   Width    Slope    Length   Pack    
+;;-------------- ---------------- ---------------- -------- -------- -------- -------- -------- --------
+1                RG1              9                10       50       500      0.01     0                        
+2                RG1              10               10       50       500      0.01     0                        
+3                RG1              13               5        50       500      0.01     0                        
+4                RG1              22               5        50       500      0.01     0                        
+5                RG1              15               15       50       500      0.01     0                        
+6                RG1              23               12       10       500      0.01     0                        
+7                RG1              19               4        10       500      0.01     0                        
+8                RG1              18               10       10       500      0.01     0                        
+
+[SUBAREAS]
+;;Subcatchment   N-Imperv   N-Perv     S-Imperv   S-Perv     PctZero    RouteTo    PctRouted 
+;;-------------- ---------- ---------- ---------- ---------- ---------- ---------- ----------
+1                0.001      0.10       0.05       0.05       25         OUTLET    
+2                0.001      0.10       0.05       0.05       25         OUTLET    
+3                0.001      0.10       0.05       0.05       25         OUTLET    
+4                0.001      0.10       0.05       0.05       25         OUTLET    
+5                0.001      0.10       0.05       0.05       25         OUTLET    
+6                0.001      0.10       0.05       0.05       25         OUTLET    
+7                0.001      0.10       0.05       0.05       25         OUTLET    
+8                0.001      0.10       0.05       0.05       25         OUTLET    
+
+[INFILTRATION]
+;;Subcatchment   MaxRate    MinRate    Decay      DryTime    MaxInfil  
+;;-------------- ---------- ---------- ---------- ---------- ----------
+1                0.35       0.25       4.14       0.50       0         
+2                0.7        0.3        4.14       0.50       0         
+3                0.7        0.3        4.14       0.50       0         
+4                0.7        0.3        4.14       0.50       0         
+5                0.7        0.3        4.14       0.50       0         
+6                0.7        0.3        4.14       0.50       0         
+7                0.7        0.3        4.14       0.50       0         
+8                0.7        0.3        4.14       0.50       0         
+
+[JUNCTIONS]
+;;               Invert     Max.       Init.      Surcharge  Ponded    
+;;Name           Elev.      Depth      Depth      Depth      Area      
+;;-------------- ---------- ---------- ---------- ---------- ----------
+10               995        3          0          0          0         
+13               995        3          0          0          0         
+14               990        3          0          0          0         
+15               987        3          0          0          0         
+16               985        3          0          0          0         
+17               980        3          0          0          0         
+19               1010       3          0          0          0         
+20               1005       3          0          0          0         
+21               990        3          0          0          0         
+22               987        3          0          0          0         
+23               990        3          0          0          0         
+24               984        3          0          0          0         
+9                1000       3          0          0          0         
+
+[OUTFALLS]
+;;               Invert     Outfall      Stage/Table      Tide
+;;Name           Elev.      Type         Time Series      Gate Route To        
+;;-------------- ---------- ------------ ---------------- ---- ----------------
+18               975        FREE                          NO                   
+
+[CONDUITS]
+;;               Inlet            Outlet                      Manning    Inlet      Outlet     Init.      Max.      
+;;Name           Node             Node             Length     N          Offset     Offset     Flow       Flow      
+;;-------------- ---------------- ---------------- ---------- ---------- ---------- ---------- ---------- ----------
+1                9                10               400        0.01       0          0          0          0         
+10               17               18               400        0.01       0          0          0          0         
+11               13               14               400        0.01       0          0          0          0         
+12               14               15               400        0.01       0          0          0          0         
+13               15               16               400        0.01       0          0          0          0         
+14               23               24               400        0.01       0          0          0          0         
+15               16               24               100        0.01       0          0          0          0         
+16               24               17               400        0.01       0          0          0          0         
+4                19               20               200        0.01       0          0          0          0         
+5                20               21               200        0.01       0          0          0          0         
+6                10               21               400        0.01       0          1          0          0         
+7                21               22               300        0.01       1          1          0          0         
+8                22               16               300        0.01       0          0          0          0         
+
+[XSECTIONS]
+;;Link           Shape        Geom1            Geom2      Geom3      Geom4      Barrels   
+;;-------------- ------------ ---------------- ---------- ---------- ---------- ----------
+1                CIRCULAR     1.5              0          0          0          1                    
+10               CIRCULAR     2                0          0          0          1                    
+11               CIRCULAR     1.5              0          0          0          1                    
+12               CIRCULAR     1.5              0          0          0          1                    
+13               CIRCULAR     1.5              0          0          0          1                    
+14               CIRCULAR     1                0          0          0          1                    
+15               CIRCULAR     2                0          0          0          1                    
+16               CIRCULAR     2                0          0          0          1                    
+4                CIRCULAR     1                0          0          0          1                    
+5                CIRCULAR     1                0          0          0          1                    
+6                CIRCULAR     1                0          0          0          1                    
+7                CIRCULAR     2                0          0          0          1                    
+8                CIRCULAR     2                0          0          0          1                    
+
+[LOSSES]
+;;Link           Inlet      Outlet     Average    Flap Gate  SeepageRate
+;;-------------- ---------- ---------- ---------- ---------- ----------
+
+[POLLUTANTS]
+;;               Mass   Rain       GW         I&I        Decay      Snow  Co-Pollut.       Co-Pollut. DWF        Init.
+;;Name           Units  Concen.    Concen.    Concen.    Coeff.     Only  Name             Fraction   Concen.    Concen.
+;;-------------- ------ ---------- ---------- ---------- ---------- ----- ---------------- ---------- ---------- ----------
+Lead             UG/L   0.0        0.0        0          0.0        NO    TSS              0.2        0          0         
+TSS              MG/L   0.0        0.0        0          0.0        NO    *                0.0        0          0         
+
+[LANDUSES]
+;;               Cleaning   Fraction   Last      
+;;Name           Interval   Available  Cleaned   
+;;-------------- ---------- ---------- ----------
+Residential      0          0          0         
+Undeveloped      0          0          0         
+
+[COVERAGES]
+;;Subcatchment   Land Use         Percent   
+;;-------------- ---------------- ----------
+1                Residential      100.00
+2                Residential      50.00
+2                Undeveloped      50.00
+3                Residential      100.00
+4                Residential      50.00
+4                Undeveloped      50.00
+5                Residential      100.00
+6                Undeveloped      100.00
+7                Undeveloped      100.00
+8                Undeveloped      100.00
+
+[LOADINGS]
+;;Subcatchment   Pollutant        Loading   
+;;-------------- ---------------- ----------
+
+[BUILDUP]
+;;LandUse        Pollutant        Function   Coeff1     Coeff2     Coeff3     Normalizer
+;;-------------- ---------------- ---------- ---------- ---------- ---------- ----------
+Residential      Lead             NONE       0          0          0          AREA      
+Residential      TSS              SAT        50         0          2          AREA      
+Undeveloped      Lead             NONE       0          0          0          AREA      
+Undeveloped      TSS              SAT        100        0          3          AREA      
+
+[WASHOFF]
+;;                                                                 Cleaning   BMP       
+;;Land Use       Pollutant        Function   Coeff1     Coeff2     Effic.     Effic.    
+;;-------------- ---------------- ---------- ---------- ---------- ---------- ----------
+Residential      Lead             EMC        0          0          0          0         
+Residential      TSS              EXP        0.1        1          0          0         
+Undeveloped      Lead             EMC        0          0          0          0         
+Undeveloped      TSS              EXP        0.1        0.7        0          0         
+
+[TIMESERIES]
+;;Name           Date       Time       Value     
+;;-------------- ---------- ---------- ----------
+;RAINFALL
+TS1                         0:00       0.0       
+TS1                         1:00       0.25      
+TS1                         2:00       0.5       
+TS1                         3:00       0.8       
+TS1                         4:00       0.4       
+TS1                         5:00       0.1       
+TS1                         6:00       0.0       
+TS1                         27:00      0.0       
+TS1                         28:00      0.4       
+TS1                         29:00      0.2       
+TS1                         30:00      0.0       
+
+[REPORT]
+INPUT      NO
+CONTROLS   NO
+SUBCATCHMENTS ALL
+NODES ALL
+LINKS ALL
+
+[TAGS]
+
+[MAP]
+DIMENSIONS       -188.4225        -154.7365        9514.7325        10196.8465      
+UNITS            None
+
+[COORDINATES]
+;;Node           X-Coord          Y-Coord         
+;;-------------- ---------------- ----------------
+10               4105.26          6947.37         
+13               2336.84          4357.89         
+14               3157.89          4294.74         
+15               3221.05          3242.11         
+16               4821.05          3326.32         
+17               6252.63          2147.37         
+19               7768.42          6736.84         
+20               5957.89          6589.47         
+21               4926.32          6105.26         
+22               4421.05          4715.79         
+23               6484.21          3978.95         
+24               5389.47          3031.58         
+9                4042.11          9600            
+18               6631.58          505.26          
+
+[VERTICES]
+;;Link           X-Coord          Y-Coord         
+;;-------------- ---------------- ----------------
+10               6673.68          1368.42         
+
+[POLYGONS]
+;;Subcatchment   X-Coord          Y-Coord         
+;;-------------- ---------------- ----------------
+1                3936.84          6905.26         
+1                3494.74          6252.63         
+1                273.68           6336.84         
+1                252.63           8526.32         
+1                463.16           9200            
+1                1157.89          9726.32         
+1                4000             9705.26         
+2                7600             9663.16         
+2                7705.26          6736.84         
+2                5915.79          6694.74         
+2                4926.32          6294.74         
+2                4189.47          7200            
+2                4126.32          9621.05         
+3                2357.89          6021.05         
+3                2400             4336.84         
+3                3031.58          4252.63         
+3                2989.47          3389.47         
+3                315.79           3410.53         
+3                294.74           6000            
+4                3473.68          6105.26         
+4                3915.79          6421.05         
+4                4168.42          6694.74         
+4                4463.16          6463.16         
+4                4821.05          6063.16         
+4                4400             5263.16         
+4                4357.89          4442.11         
+4                4547.37          3705.26         
+4                4000             3431.58         
+4                3326.32          3368.42         
+4                3242.11          3536.84         
+4                3136.84          5157.89         
+4                2589.47          5178.95         
+4                2589.47          6063.16         
+4                3284.21          6063.16         
+4                3705.26          6231.58         
+4                4126.32          6715.79         
+5                2568.42          3200            
+5                4905.26          3136.84         
+5                5221.05          2842.11         
+5                5747.37          2421.05         
+5                6463.16          1578.95         
+5                6610.53          968.42          
+5                6589.47          505.26          
+5                1305.26          484.21          
+5                968.42           336.84          
+5                315.79           778.95          
+5                315.79           3115.79         
+6                9052.63          4147.37         
+6                7894.74          4189.47         
+6                6442.11          4105.26         
+6                5915.79          3642.11         
+6                5326.32          3221.05         
+6                4631.58          4231.58         
+6                4568.42          5010.53         
+6                4884.21          5768.42         
+6                5368.42          6294.74         
+6                6042.11          6568.42         
+6                8968.42          6526.32         
+7                8736.84          9642.11         
+7                9010.53          9389.47         
+7                9010.53          8631.58         
+7                9052.63          6778.95         
+7                7789.47          6800            
+7                7726.32          9642.11         
+8                9073.68          2063.16         
+8                9052.63          778.95          
+8                8505.26          336.84          
+8                7431.58          315.79          
+8                7410.53          484.21          
+8                6842.11          505.26          
+8                6842.11          589.47          
+8                6821.05          1178.95         
+8                6547.37          1831.58         
+8                6147.37          2378.95         
+8                5600             3073.68         
+8                6589.47          3894.74         
+8                8863.16          3978.95         
+
+[SYMBOLS]
+;;Gage           X-Coord          Y-Coord         
+;;-------------- ---------------- ----------------
+RG1              10084.21         8210.53         

--- a/swmmio/tests/data/Example1b.rpt
+++ b/swmmio/tests/data/Example1b.rpt
@@ -1,0 +1,292 @@
+
+  EPA STORM WATER MANAGEMENT MODEL - VERSION 5.1 (Build 5.1.013)
+  --------------------------------------------------------------
+
+  Example 1 
+  
+  
+  *********************************************************
+  NOTE: The summary statistics displayed in this report are
+  based on results found at every computational time step,  
+  not just on results from each reporting time step.
+  *********************************************************
+  
+  ****************
+  Analysis Options
+  ****************
+  Flow Units ............... CFS
+  Process Models:
+    Rainfall/Runoff ........ YES
+    RDII ................... NO
+    Snowmelt ............... NO
+    Groundwater ............ NO
+    Flow Routing ........... YES
+    Ponding Allowed ........ NO
+    Water Quality .......... YES
+  Infiltration Method ...... HORTON
+  Flow Routing Method ...... KINWAVE
+  Starting Date ............ 01/01/1998 00:00:00
+  Ending Date .............. 01/02/1998 12:00:00
+  Antecedent Dry Days ...... 5.0
+  Report Time Step ......... 01:00:00
+  Wet Time Step ............ 00:15:00
+  Dry Time Step ............ 01:00:00
+  Routing Time Step ........ 60.00 sec
+  
+  
+  **************************        Volume         Depth
+  Runoff Quantity Continuity     acre-feet        inches
+  **************************     ---------       -------
+  Total Precipitation ......        15.679         2.650
+  Evaporation Loss .........         0.000         0.000
+  Infiltration Loss ........         9.346         1.580
+  Surface Runoff ...........         6.295         1.064
+  Final Storage ............         0.081         0.014
+  Continuity Error (%) .....        -0.272
+  
+  
+  **************************          Lead           TSS
+  Runoff Quality Continuity            lbs           lbs
+  **************************    ----------    ----------
+  Initial Buildup ..........         0.000      3433.036
+  Surface Buildup ..........         0.086       312.924
+  Wet Deposition ...........         0.000         0.000
+  Sweeping Removal .........         0.000         0.000
+  Infiltration Loss ........         0.000         0.000
+  BMP Removal ..............         0.000         0.000
+  Surface Runoff ...........         0.086       431.367
+  Remaining Buildup ........         0.000      3314.593
+  Continuity Error (%) .....         0.000         0.000
+  
+  
+  **************************        Volume        Volume
+  Flow Routing Continuity        acre-feet      10^6 gal
+  **************************     ---------     ---------
+  Dry Weather Inflow .......         0.000         0.000
+  Wet Weather Inflow .......         6.295         2.051
+  Groundwater Inflow .......         0.000         0.000
+  RDII Inflow ..............         0.000         0.000
+  External Inflow ..........         0.000         0.000
+  External Outflow .........         5.874         1.914
+  Flooding Loss ............         0.415         0.135
+  Evaporation Loss .........         0.000         0.000
+  Exfiltration Loss ........         0.000         0.000
+  Initial Stored Volume ....         0.000         0.000
+  Final Stored Volume ......         0.000         0.000
+  Continuity Error (%) .....         0.097
+  
+  
+  **************************          Lead           TSS
+  Quality Routing Continuity           lbs           lbs
+  **************************    ----------    ----------
+  Dry Weather Inflow .......         0.000         0.000
+  Wet Weather Inflow .......         0.086       431.367
+  Groundwater Inflow .......         0.000         0.000
+  RDII Inflow ..............         0.000         0.000
+  External Inflow ..........         0.000         0.000
+  External Outflow .........         0.082       409.794
+  Flooding Loss ............         0.004        22.236
+  Exfiltration Loss ........         0.000         0.000
+  Mass Reacted .............         0.000         0.000
+  Initial Stored Mass ......         0.000         0.000
+  Final Stored Mass ........         0.000         0.000
+  Continuity Error (%) .....        -0.154        -0.154
+  
+  
+  ********************************
+  Highest Flow Instability Indexes
+  ********************************
+  All links are stable.
+  
+  
+  *************************
+  Routing Time Step Summary
+  *************************
+  Minimum Time Step           :    60.00 sec
+  Average Time Step           :    60.00 sec
+  Maximum Time Step           :    60.00 sec
+  Percent in Steady State     :     0.00
+  Average Iterations per Step :     1.47
+  Percent Not Converging      :     0.00
+  
+  
+  ***************************
+  Subcatchment Runoff Summary
+  ***************************
+  
+  ------------------------------------------------------------------------------------------------------------------------------
+                            Total      Total      Total      Total     Imperv       Perv      Total       Total     Peak  Runoff
+                           Precip      Runon       Evap      Infil     Runoff     Runoff     Runoff      Runoff   Runoff   Coeff
+  Subcatchment                 in         in         in         in         in         in         in    10^6 gal      CFS
+  ------------------------------------------------------------------------------------------------------------------------------
+  1                          2.65       0.00       0.00       1.16       1.32       0.17       1.48        0.40     4.66   0.559
+  2                          2.65       0.00       0.00       1.21       1.32       0.11       1.43        0.39     4.52   0.539
+  3                          2.65       0.00       0.00       1.16       1.32       0.17       1.49        0.20     2.45   0.561
+  4                          2.65       0.00       0.00       1.16       1.32       0.17       1.49        0.20     2.45   0.561
+  5                          2.65       0.00       0.00       1.24       1.31       0.09       1.40        0.57     6.56   0.528
+  6                          2.65       0.00       0.00       2.27       0.26       0.12       0.38        0.12     1.50   0.143
+  7                          2.65       0.00       0.00       2.14       0.26       0.25       0.51        0.06     0.79   0.194
+  8                          2.65       0.00       0.00       2.25       0.26       0.13       0.40        0.11     1.33   0.150
+  
+  
+  ****************************
+  Subcatchment Washoff Summary
+  ****************************
+  
+  ------------------------------------------------
+                                Lead           TSS
+  Subcatchment                   lbs           lbs
+  ------------------------------------------------
+  1                            0.010        50.074
+  2                            0.018        90.586
+  3                            0.005        25.144
+  4                            0.009        46.097
+  5                            0.014        71.172
+  6                            0.013        65.843
+  7                            0.005        26.025
+  8                            0.011        56.427
+  ------------------------------------------------
+  System                       0.086       431.367
+  
+  
+  ******************
+  Node Depth Summary
+  ******************
+  
+  ---------------------------------------------------------------------------------
+                                 Average  Maximum  Maximum  Time of Max    Reported
+                                   Depth    Depth      HGL   Occurrence   Max Depth
+  Node                 Type         Feet     Feet     Feet  days hr:min        Feet
+  ---------------------------------------------------------------------------------
+  10                   JUNCTION     0.32     3.00   998.00     0  02:17        3.00
+  13                   JUNCTION     0.06     0.41   995.41     0  04:01        0.41
+  14                   JUNCTION     0.06     0.46   990.46     0  04:01        0.46
+  15                   JUNCTION     0.15     1.15   988.15     0  04:01        1.15
+  16                   JUNCTION     0.17     1.14   986.14     0  04:01        1.14
+  17                   JUNCTION     0.18     1.14   981.14     0  04:02        1.14
+  19                   JUNCTION     0.03     0.22  1010.22     0  04:01        0.22
+  20                   JUNCTION     0.03     0.22  1005.22     0  04:02        0.22
+  21                   JUNCTION     1.16     2.00   992.00     0  02:55        2.00
+  22                   JUNCTION     1.11     1.58   988.58     0  04:02        1.58
+  23                   JUNCTION     0.05     0.35   990.35     0  04:01        0.35
+  24                   JUNCTION     0.18     1.14   985.14     0  04:01        1.14
+  9                    JUNCTION     0.09     0.57  1000.57     0  04:01        0.57
+  18                   OUTFALL      0.17     1.07   976.07     0  04:02        1.06
+  
+  
+  *******************
+  Node Inflow Summary
+  *******************
+  
+  -------------------------------------------------------------------------------------------------
+                                  Maximum  Maximum                  Lateral       Total        Flow
+                                  Lateral    Total  Time of Max      Inflow      Inflow     Balance
+                                   Inflow   Inflow   Occurrence      Volume      Volume       Error
+  Node                 Type           CFS      CFS  days hr:min    10^6 gal    10^6 gal     Percent
+  -------------------------------------------------------------------------------------------------
+  10                   JUNCTION      4.52     9.17     0  04:01       0.388        0.79      -0.000
+  13                   JUNCTION      2.45     2.45     0  04:01       0.202       0.202       0.000
+  14                   JUNCTION      0.00     2.44     0  04:01           0       0.202       0.000
+  15                   JUNCTION      6.56     9.00     0  04:01        0.57       0.771       0.000
+  16                   JUNCTION      0.00    16.82     0  04:01           0        1.69       0.000
+  17                   JUNCTION      0.00    18.30     0  04:02           0        1.81       0.000
+  19                   JUNCTION      0.79     0.79     0  04:01      0.0558      0.0558       0.000
+  20                   JUNCTION      0.00     0.78     0  04:02           0      0.0558       0.000
+  21                   JUNCTION      0.00     5.42     0  04:02           0       0.714       0.000
+  22                   JUNCTION      2.45     7.86     0  04:01       0.202       0.915       0.000
+  23                   JUNCTION      1.50     1.50     0  04:01       0.124       0.124      -0.000
+  24                   JUNCTION      0.00    18.31     0  04:01           0        1.81       0.000
+  9                    JUNCTION      4.66     4.66     0  04:01       0.402       0.402      -0.000
+  18                   OUTFALL       1.33    19.60     0  04:02       0.108        1.91       0.000
+  
+  
+  *********************
+  Node Flooding Summary
+  *********************
+  
+  Flooding refers to all water that overflows a node, whether it ponds or not.
+  --------------------------------------------------------------------------
+                                                             Total   Maximum
+                                 Maximum   Time of Max       Flood    Ponded
+                        Hours       Rate    Occurrence      Volume    Volume
+  Node                 Flooded       CFS   days hr:min    10^6 gal  1000 ft3
+  --------------------------------------------------------------------------
+  10                      2.82      4.53      0  04:01       0.135     0.000
+  
+  
+  ***********************
+  Outfall Loading Summary
+  ***********************
+  
+  ---------------------------------------------------------------------------------------
+                         Flow       Avg       Max       Total         Total         Total
+                         Freq      Flow      Flow      Volume          Lead           TSS
+  Outfall Node           Pcnt       CFS       CFS    10^6 gal           lbs           lbs
+  ---------------------------------------------------------------------------------------
+  18                    72.87      2.71     19.60       1.914         0.082       409.794
+  ---------------------------------------------------------------------------------------
+  System                72.87      2.71     19.60       1.914         0.082       409.794
+  
+  
+  ********************
+  Link Flow Summary
+  ********************
+  
+  -----------------------------------------------------------------------------
+                                 Maximum  Time of Max   Maximum    Max/    Max/
+                                  |Flow|   Occurrence   |Veloc|    Full    Full
+  Link                 Type          CFS  days hr:min    ft/sec    Flow   Depth
+  -----------------------------------------------------------------------------
+  1                    CONDUIT      4.65     0  04:01      7.61    0.30    0.38
+  10                   CONDUIT     18.30     0  04:02     10.74    0.56    0.53
+  11                   CONDUIT      2.44     0  04:01      6.36    0.16    0.27
+  12                   CONDUIT      2.44     0  04:02      5.30    0.21    0.31
+  13                   CONDUIT      8.97     0  04:01      6.24    0.93    0.76
+  14                   CONDUIT      1.49     0  04:01      6.12    0.26    0.35
+  15                   CONDUIT     16.82     0  04:01      9.67    0.57    0.54
+  16                   CONDUIT     18.30     0  04:02      9.87    0.62    0.57
+  4                    CONDUIT      0.78     0  04:02      6.11    0.11    0.22
+  5                    CONDUIT      0.78     0  04:02      8.99    0.06    0.17
+  6                    CONDUIT      4.93     0  02:53      7.01    1.06    1.00
+  7                    CONDUIT      5.42     0  04:02      7.16    0.18    0.29
+  8                    CONDUIT      7.85     0  04:01      6.84    0.33    0.39
+  
+  
+  *************************
+  Conduit Surcharge Summary
+  *************************
+  
+  ----------------------------------------------------------------------------
+                                                           Hours        Hours 
+                         --------- Hours Full --------   Above Full   Capacity
+  Conduit                Both Ends  Upstream  Dnstream   Normal Flow   Limited
+  ----------------------------------------------------------------------------
+  6                           2.80      2.80      2.80      2.80         2.80
+  
+  
+  ***************************
+  Link Pollutant Load Summary
+  ***************************
+  
+  ------------------------------------------------
+                                Lead           TSS
+  Link                           lbs           lbs
+  ------------------------------------------------
+  1                            0.010        50.048
+  10                           0.071       353.368
+  11                           0.005        25.132
+  12                           0.005        25.120
+  13                           0.019        96.266
+  14                           0.013        65.724
+  15                           0.058       287.506
+  16                           0.071       353.262
+  4                            0.005        25.983
+  5                            0.005        25.979
+  6                            0.024       119.067
+  7                            0.029       145.042
+  8                            0.038       191.116
+  
+
+  Analysis begun on:  Thu Sep 24 13:34:29 2020
+  Analysis ended on:  Thu Sep 24 13:34:29 2020
+  Total elapsed time: < 1 sec

--- a/swmmio/tests/data/Example6.inp
+++ b/swmmio/tests/data/Example6.inp
@@ -1,0 +1,164 @@
+[TITLE]
+Example 6
+Circular Culvert with Roadway Overtopping
+and Upstream Storage
+
+
+[OPTIONS]
+;;Options            Value
+;;------------------ ------------
+FLOW_UNITS           CFS
+INFILTRATION         HORTON
+FLOW_ROUTING         DYNWAVE
+LINK_OFFSETS         DEPTH
+MIN_SLOPE            0
+ALLOW_PONDING        NO
+SKIP_STEADY_STATE    NO
+START_DATE           06/08/2015
+START_TIME           00:00:00
+REPORT_START_DATE    06/08/2015
+REPORT_START_TIME    00:00:00
+END_DATE             06/08/2015
+END_TIME             05:00:00
+SWEEP_START          01/01
+SWEEP_END            12/31
+DRY_DAYS             0
+REPORT_STEP          00:07:30
+WET_STEP             00:05:00
+DRY_STEP             01:00:00
+ROUTING_STEP         5
+RULE_STEP            00:00:00
+INERTIAL_DAMPING     PARTIAL
+NORMAL_FLOW_LIMITED  BOTH
+FORCE_MAIN_EQUATION  H-W
+VARIABLE_STEP        0.75
+LENGTHENING_STEP     0
+MIN_SURFAREA         12.557
+MAX_TRIALS           8
+HEAD_TOLERANCE       0.005
+SYS_FLOW_TOL         5
+LAT_FLOW_TOL         5
+MINIMUM_STEP         0.5
+THREADS              1
+
+[EVAPORATION]
+;;Type          Parameters
+;;------------- ----------
+CONSTANT     0.0
+DRY_ONLY     NO
+
+[JUNCTIONS]
+;;               Invert     Max.       Init.      Surcharge  Ponded    
+;;Name           Elev.      Depth      Depth      Depth      Area      
+;;-------------- ---------- ---------- ---------- ---------- ----------
+Outlet           868        0          0          0          0         
+
+[OUTFALLS]
+;;               Invert     Outfall      Stage/Table      Tide
+;;Name           Elev.      Type         Time Series      Gate Route To        
+;;-------------- ---------- ------------ ---------------- ---- ----------------
+TailWater        858        FIXED        859.5            NO                   
+
+[STORAGE]
+;;               Invert   Max.     Init.    Storage    Curve                               Evap.   
+;;Name           Elev.    Depth    Depth    Curve      Params                              Frac.    Infiltration parameters
+;;-------------- -------- -------- -------- ---------- -------- -------- -------- -------- -------- -----------------------
+Inlet            878      9        0        TABULAR    StorageCurve               0        0       
+
+[CONDUITS]
+;;               Inlet            Outlet                      Manning    Inlet      Outlet     Init.      Max.      
+;;Name           Node             Node             Length     N          Offset     Offset     Flow       Flow      
+;;-------------- ---------------- ---------------- ---------- ---------- ---------- ---------- ---------- ----------
+Channel          Outlet           TailWater        200        0.03       0          0          0          0         
+Culvert          Inlet            Outlet           200        0.014      0          0          0          0         
+
+[WEIRS]
+;;               Inlet            Outlet           Weir         Crest      Disch.     Flap End      End       
+;;Name           Node             Node             Type         Height     Coeff.     Gate Con.     Coeff.     Surcharge  RoadWidth  RoadSurf   Coeff. Curve
+;;-------------- ---------------- ---------------- ------------ ---------- ---------- ---- -------- ---------- ---------- ---------- ---------- ----------------
+Roadway          Inlet            Outlet           ROADWAY      9          3.33       NO   0        0          NO         40         GRAVEL    
+
+[XSECTIONS]
+;;Link           Shape        Geom1            Geom2      Geom3      Geom4      Barrels   
+;;-------------- ------------ ---------------- ---------- ---------- ---------- ----------
+Channel          TRAPEZOIDAL  9                10         2          2          1                    
+Culvert          CIRCULAR     3                0          0          0          2          4         
+Roadway          RECT_OPEN    50               200        0          0         
+
+[LOSSES]
+;;Link           Inlet      Outlet     Average    Flap Gate  SeepageRate
+;;-------------- ---------- ---------- ---------- ---------- ----------
+
+[INFLOWS]
+;;                                                 Param    Units    Scale    Baseline Baseline
+;;Node           Parameter        Time Series      Type     Factor   Factor   Value    Pattern
+;;-------------- ---------------- ---------------- -------- -------- -------- -------- --------
+Inlet            FLOW             Inflow           FLOW     1.0      1.0                       
+
+[CURVES]
+;;Name           Type       X-Value    Y-Value   
+;;-------------- ---------- ---------- ----------
+StorageCurve     Storage    0          0         
+StorageCurve                2          9583      
+StorageCurve                4          33977     
+StorageCurve                6          72310     
+StorageCurve                8          136778    
+
+[TIMESERIES]
+;;Name           Date       Time       Value     
+;;-------------- ---------- ---------- ----------
+Inflow                      0          0         
+Inflow                      .125       9         
+Inflow                      .25        10        
+Inflow                      .375       11        
+Inflow                      .5         13        
+Inflow                      .625       17        
+Inflow                      .75        28        
+Inflow                      .875       40        
+Inflow                      1          80        
+Inflow                      1.125      136       
+Inflow                      1.25       190       
+Inflow                      1.375      220       
+Inflow                      1.5        220       
+Inflow                      1.625      201       
+Inflow                      1.75       170       
+Inflow                      1.875      140       
+Inflow                      2          120       
+Inflow                      2.125      98        
+Inflow                      2.25       82        
+Inflow                      2.375      70        
+Inflow                      2.5        60        
+Inflow                      2.625      53        
+Inflow                      2.75       47        
+Inflow                      2.875      41        
+
+[REPORT]
+INPUT      NO
+CONTROLS   NO
+SUBCATCHMENTS ALL
+NODES ALL
+LINKS ALL
+
+[TAGS]
+
+[MAP]
+DIMENSIONS       1408.9383        6118.83065       6238.6797        7216.52835      
+UNITS            None
+
+[COORDINATES]
+;;Node           X-Coord          Y-Coord         
+;;-------------- ---------------- ----------------
+Outlet           4206.542         6357.994        
+TailWater        6019.146         6168.726        
+Inlet            1628.472         6476.537        
+
+[VERTICES]
+;;Link           X-Coord          Y-Coord         
+;;-------------- ---------------- ----------------
+Roadway          2311.068         7166.633        
+Roadway          3762.491         7151.463        
+
+[LABELS]
+;;X-Coord        Y-Coord          Label           
+1651.426         7755.664         "Circular Culvert with Roadway Overtopping and Upstream Storage"  "Arial" 12 1 1
+

--- a/swmmio/tests/data/Example6.rpt
+++ b/swmmio/tests/data/Example6.rpt
@@ -1,0 +1,192 @@
+
+  EPA STORM WATER MANAGEMENT MODEL - VERSION 5.1 (Build 5.1.013)
+  --------------------------------------------------------------
+
+  Example 6 
+  Circular Culvert with Roadway Overtopping 
+  and Upstream Storage 
+  
+  
+  *********************************************************
+  NOTE: The summary statistics displayed in this report are
+  based on results found at every computational time step,  
+  not just on results from each reporting time step.
+  *********************************************************
+  
+  ****************
+  Analysis Options
+  ****************
+  Flow Units ............... CFS
+  Process Models:
+    Rainfall/Runoff ........ NO
+    RDII ................... NO
+    Snowmelt ............... NO
+    Groundwater ............ NO
+    Flow Routing ........... YES
+    Ponding Allowed ........ NO
+    Water Quality .......... NO
+  Flow Routing Method ...... DYNWAVE
+  Surcharge Method ......... EXTRAN
+  Starting Date ............ 06/08/2015 00:00:00
+  Ending Date .............. 06/08/2015 05:00:00
+  Antecedent Dry Days ...... 0.0
+  Report Time Step ......... 00:07:30
+  Routing Time Step ........ 5.00 sec
+  Variable Time Step ....... YES
+  Maximum Trials ........... 8
+  Number of Threads ........ 1
+  Head Tolerance ........... 0.005000 ft
+  
+  
+  **************************        Volume        Volume
+  Flow Routing Continuity        acre-feet      10^6 gal
+  **************************     ---------     ---------
+  Dry Weather Inflow .......         0.000         0.000
+  Wet Weather Inflow .......         0.000         0.000
+  Groundwater Inflow .......         0.000         0.000
+  RDII Inflow ..............         0.000         0.000
+  External Inflow ..........        21.025         6.851
+  External Outflow .........        21.025         6.851
+  Flooding Loss ............         0.000         0.000
+  Evaporation Loss .........         0.000         0.000
+  Exfiltration Loss ........         0.000         0.000
+  Initial Stored Volume ....         0.040         0.013
+  Final Stored Volume ......         0.045         0.015
+  Continuity Error (%) .....        -0.025
+  
+  
+  ***************************
+  Time-Step Critical Elements
+  ***************************
+  None
+  
+  
+  ********************************
+  Highest Flow Instability Indexes
+  ********************************
+  Link Culvert (2)
+  Link Channel (2)
+  
+  
+  *************************
+  Routing Time Step Summary
+  *************************
+  Minimum Time Step           :     4.50 sec
+  Average Time Step           :     5.00 sec
+  Maximum Time Step           :     5.00 sec
+  Percent in Steady State     :     0.00
+  Average Iterations per Step :     2.00
+  Percent Not Converging      :     0.00
+  
+  
+  ******************
+  Node Depth Summary
+  ******************
+  
+  ---------------------------------------------------------------------------------
+                                 Average  Maximum  Maximum  Time of Max    Reported
+                                   Depth    Depth      HGL   Occurrence   Max Depth
+  Node                 Type         Feet     Feet     Feet  days hr:min        Feet
+  ---------------------------------------------------------------------------------
+  Outlet               JUNCTION     0.46     1.16   869.16     0  01:49        1.16
+  TailWater            OUTFALL      1.50     1.50   859.50     0  00:00        1.50
+  Inlet                STORAGE      2.17     6.36   884.36     0  01:49        6.35
+  
+  
+  *******************
+  Node Inflow Summary
+  *******************
+  
+  -------------------------------------------------------------------------------------------------
+                                  Maximum  Maximum                  Lateral       Total        Flow
+                                  Lateral    Total  Time of Max      Inflow      Inflow     Balance
+                                   Inflow   Inflow   Occurrence      Volume      Volume       Error
+  Node                 Type           CFS      CFS  days hr:min    10^6 gal    10^6 gal     Percent
+  -------------------------------------------------------------------------------------------------
+  Outlet               JUNCTION      0.00   151.66     0  01:49           0        6.85       0.001
+  TailWater            OUTFALL       0.00   151.66     0  01:49           0        6.85       0.000
+  Inlet                STORAGE     220.00   220.00     0  01:22        6.85        6.85      -0.001
+  
+  
+  **********************
+  Node Surcharge Summary
+  **********************
+  
+  No nodes were surcharged.
+  
+  
+  *********************
+  Node Flooding Summary
+  *********************
+  
+  No nodes were flooded.
+  
+  
+  **********************
+  Storage Volume Summary
+  **********************
+  
+  --------------------------------------------------------------------------------------------------
+                         Average     Avg  Evap Exfil       Maximum     Max    Time of Max    Maximum
+                          Volume    Pcnt  Pcnt  Pcnt        Volume    Pcnt     Occurrence    Outflow
+  Storage Unit          1000 ft3    Full  Loss  Loss      1000 ft3    Full    days hr:min        CFS
+  --------------------------------------------------------------------------------------------------
+  Inlet                   42.238       8     0     0       187.247      36       0  01:49     151.66
+  
+  
+  ***********************
+  Outfall Loading Summary
+  ***********************
+  
+  -----------------------------------------------------------
+                         Flow       Avg       Max       Total
+                         Freq      Flow      Flow      Volume
+  Outfall Node           Pcnt       CFS       CFS    10^6 gal
+  -----------------------------------------------------------
+  TailWater             75.53     67.34    151.66       6.851
+  -----------------------------------------------------------
+  System                75.53     67.34    151.66       6.851
+  
+  
+  ********************
+  Link Flow Summary
+  ********************
+  
+  -----------------------------------------------------------------------------
+                                 Maximum  Time of Max   Maximum    Max/    Max/
+                                  |Flow|   Occurrence   |Veloc|    Full    Full
+  Link                 Type          CFS  days hr:min    ft/sec    Flow   Depth
+  -----------------------------------------------------------------------------
+  Channel              CONDUIT    151.66     0  01:49      9.01    0.02    0.15
+  Culvert              CONDUIT    151.66     0  01:49     14.51    0.55    0.69
+  Roadway              WEIR         0.00     0  00:00                      0.00
+  
+  
+  ***************************
+  Flow Classification Summary
+  ***************************
+  
+  -------------------------------------------------------------------------------------
+                      Adjusted    ---------- Fraction of Time in Flow Class ---------- 
+                       /Actual         Up    Down  Sub   Sup   Up    Down  Norm  Inlet 
+  Conduit               Length    Dry  Dry   Dry   Crit  Crit  Crit  Crit  Ltd   Ctrl  
+  -------------------------------------------------------------------------------------
+  Channel                 1.00   0.00  0.00  0.00  0.66  0.34  0.00  0.00  1.00  0.00
+  Culvert                 1.00   0.00  0.30  0.00  0.01  0.70  0.00  0.00  0.00  1.00
+  
+  
+  *************************
+  Conduit Surcharge Summary
+  *************************
+  
+  ----------------------------------------------------------------------------
+                                                           Hours        Hours 
+                         --------- Hours Full --------   Above Full   Capacity
+  Conduit                Both Ends  Upstream  Dnstream   Normal Flow   Limited
+  ----------------------------------------------------------------------------
+  Culvert                     0.01      1.75      0.01      0.01         0.01
+  
+
+  Analysis begun on:  Tue Sep 22 13:31:04 2020
+  Analysis ended on:  Tue Sep 22 13:31:04 2020
+  Total elapsed time: < 1 sec

--- a/swmmio/tests/data/__init__.py
+++ b/swmmio/tests/data/__init__.py
@@ -25,6 +25,8 @@ MODEL_GREEN_AMPT = os.path.join(DATA_PATH, 'model_green_ampt.inp')
 MODEL_MOD_GREEN_AMPT = os.path.join(DATA_PATH, 'model_mod_green_ampt.inp')
 MODEL_CURVE_NUMBER = os.path.join(DATA_PATH, 'model_curve_num.inp')
 MODEL_MOD_HORTON = os.path.join(DATA_PATH, 'model_mod_horton.inp')
+MODEL_EX_1 = os.path.join(DATA_PATH, 'Example1.inp')
+MODEL_EX_6 = os.path.join(DATA_PATH, 'Example6.inp')
 
 # test rpt paths
 RPT_FULL_FEATURES = os.path.join(DATA_PATH, 'model_full_features_network.rpt')

--- a/swmmio/tests/data/__init__.py
+++ b/swmmio/tests/data/__init__.py
@@ -26,6 +26,7 @@ MODEL_MOD_GREEN_AMPT = os.path.join(DATA_PATH, 'model_mod_green_ampt.inp')
 MODEL_CURVE_NUMBER = os.path.join(DATA_PATH, 'model_curve_num.inp')
 MODEL_MOD_HORTON = os.path.join(DATA_PATH, 'model_mod_horton.inp')
 MODEL_EX_1 = os.path.join(DATA_PATH, 'Example1.inp')
+MODEL_EX_1B = os.path.join(DATA_PATH, 'Example1b.inp')
 MODEL_EX_6 = os.path.join(DATA_PATH, 'Example6.inp')
 
 # test rpt paths

--- a/swmmio/tests/test_model_elements.py
+++ b/swmmio/tests/test_model_elements.py
@@ -6,7 +6,7 @@ import pandas as pd
 import swmmio
 import swmmio.utils.functions
 import swmmio.utils.text
-from swmmio.tests.data import MODEL_FULL_FEATURES_XY, MODEL_FULL_FEATURES__NET_PATH, MODEL_A_PATH
+from swmmio.tests.data import MODEL_FULL_FEATURES_XY, MODEL_FULL_FEATURES__NET_PATH, MODEL_A_PATH, MODEL_EX_1, MODEL_EX_6
 from swmmio import Model, dataframe_from_inp
 
 from swmmio.utils.dataframes import get_link_coords
@@ -138,3 +138,8 @@ def test_remove_model_section():
 
         # confirm subcatchments returns an empty df
         assert m2.subcatchments.dataframe.empty
+
+def test_example_1():
+    model = swmmio.Model(MODEL_EX_1)
+    element_types = ['nodes', 'links', 'subcatchments']
+    elem_dict = {element: model.__getattribute__(element).geojson for element in element_types}

--- a/swmmio/tests/test_model_elements.py
+++ b/swmmio/tests/test_model_elements.py
@@ -6,7 +6,7 @@ import pandas as pd
 import swmmio
 import swmmio.utils.functions
 import swmmio.utils.text
-from swmmio.tests.data import MODEL_FULL_FEATURES_XY, MODEL_FULL_FEATURES__NET_PATH, MODEL_A_PATH, MODEL_EX_1, MODEL_EX_6
+from swmmio.tests.data import MODEL_FULL_FEATURES_XY, MODEL_FULL_FEATURES__NET_PATH, MODEL_A_PATH, MODEL_EX_1, MODEL_EX_1B
 from swmmio import Model, dataframe_from_inp
 
 from swmmio.utils.dataframes import get_link_coords
@@ -139,7 +139,17 @@ def test_remove_model_section():
         # confirm subcatchments returns an empty df
         assert m2.subcatchments.dataframe.empty
 
+
 def test_example_1():
     model = swmmio.Model(MODEL_EX_1)
     element_types = ['nodes', 'links', 'subcatchments']
     elem_dict = {element: model.__getattribute__(element).geojson for element in element_types}
+    swmm_version = model.rpt.swmm_version
+    assert(swmm_version['major'] == 5)
+    assert(swmm_version['minor'] == 1)  
+    assert(swmm_version['patch'] == 12)
+
+    model_b = swmmio.Model(MODEL_EX_1B)
+    swmm_version = model_b.rpt.swmm_version 
+    assert(swmm_version['patch'] == 13)
+    elem_dict = {element: model_b.__getattribute__(element).geojson for element in element_types}

--- a/swmmio/utils/dataframes.py
+++ b/swmmio/utils/dataframes.py
@@ -53,7 +53,7 @@ def create_dataframe_multi_index(inp_path, section='CURVES'):
     return df
 
 
-def dataframe_from_rpt(rpt_path, section, element_id=None):
+def dataframe_from_rpt(rpt_path, section, element_id=None, swmm_version=None):
     """
     create a dataframe from a section of an RPT file
     :param rpt_path:
@@ -62,7 +62,7 @@ def dataframe_from_rpt(rpt_path, section, element_id=None):
     """
 
     # get list of all section headers in rpt to use as section ending flags
-    headers = get_rpt_sections_details(rpt_path)
+    headers = get_rpt_sections_details(rpt_path, swmm_version)
 
     if section not in headers:
         warnings.warn(f'{section} section not found in {rpt_path}')

--- a/swmmio/utils/text.py
+++ b/swmmio/utils/text.py
@@ -216,10 +216,11 @@ def get_inp_sections_details(inp_path, include_brackets=False):
 def update_report_header(swmm_version, rpt_headers):
     from swmmio.defs import SWMM5_VERSION
     
-    for patch in SWMM5_VERSION:
-        patch = int(patch)
-        if swmm_version['patch'] >= patch:
-            update_rpt = normalize_inp_config(SWMM5_VERSION[patch]['rpt_sections'])
+    for version in SWMM5_VERSION:
+        version_value = float(version)
+        rpt_version = float(f"{swmm_version['minor']}.{swmm_version['minor']}")
+        if swmm_version['patch'] >= version_value:
+            update_rpt = normalize_inp_config(SWMM5_VERSION[version]['rpt_sections'])
             rpt_headers.update(update_rpt)
 
                 

--- a/swmmio/utils/text.py
+++ b/swmmio/utils/text.py
@@ -6,6 +6,7 @@ from swmmio.defs import INFILTRATION_COLS, INP_SECTION_TAGS
 from collections import OrderedDict, deque
 from io import StringIO
 from swmmio.utils.functions import format_inp_section_header
+from swmmio.defs.sectionheaders import normalize_inp_config
 
 
 def inline_comments_in_inp(filepath, overwrite=False):
@@ -211,7 +212,7 @@ def get_inp_sections_details(inp_path, include_brackets=False):
     return found_sects
 
 
-def get_rpt_sections_details(rpt_path):
+def get_rpt_sections_details(rpt_path, swmm_version=None):
     """
 
     :param rpt_path:
@@ -220,9 +221,16 @@ def get_rpt_sections_details(rpt_path):
     # >>> MODEL_FULL_FEATURES__NET_PATH
 
     """
-    from swmmio.defs import RPT_OBJECTS
+    from swmmio.defs import RPT_OBJECTS, SWMM5_VERSION
     found_sects = OrderedDict()
+    rpt_headers = RPT_OBJECTS.copy()
 
+    for patch in SWMM5_VERSION:
+        patch = int(patch)
+        if swmm_version['patch'] >= patch:
+            update_rpt = normalize_inp_config(SWMM5_VERSION[patch]['rpt_sections'])
+            rpt_headers.update(update_rpt)
+        
     with open(rpt_path) as f:
         buff3line = deque()
         for line in f:
@@ -239,8 +247,8 @@ def get_rpt_sections_details(rpt_path):
                     len(buff3line[1].strip()) > 0):
                 header = buff3line[1].strip()
 
-                if header in RPT_OBJECTS:
-                    found_sects[header] = RPT_OBJECTS[header]
+                if header in rpt_headers:
+                    found_sects[header] = rpt_headers[header]
                 else:
                     # unrecognized section
                     found_sects[header] = OrderedDict(columns=['blob'])

--- a/swmmio/utils/text.py
+++ b/swmmio/utils/text.py
@@ -212,6 +212,17 @@ def get_inp_sections_details(inp_path, include_brackets=False):
     return found_sects
 
 
+
+def update_report_header(swmm_version, rpt_headers):
+    from swmmio.defs import SWMM5_VERSION
+    
+    for patch in SWMM5_VERSION:
+        patch = int(patch)
+        if swmm_version['patch'] >= patch:
+            update_rpt = normalize_inp_config(SWMM5_VERSION[patch]['rpt_sections'])
+            rpt_headers.update(update_rpt)
+
+                
 def get_rpt_sections_details(rpt_path, swmm_version=None):
     """
 
@@ -221,15 +232,12 @@ def get_rpt_sections_details(rpt_path, swmm_version=None):
     # >>> MODEL_FULL_FEATURES__NET_PATH
 
     """
-    from swmmio.defs import RPT_OBJECTS, SWMM5_VERSION
+    from swmmio.defs import RPT_OBJECTS
     found_sects = OrderedDict()
     rpt_headers = RPT_OBJECTS.copy()
 
-    for patch in SWMM5_VERSION:
-        patch = int(patch)
-        if swmm_version['patch'] >= patch:
-            update_rpt = normalize_inp_config(SWMM5_VERSION[patch]['rpt_sections'])
-            rpt_headers.update(update_rpt)
+    if swmm_version:
+        update_report_header(swmm_version, rpt_headers)
         
     with open(rpt_path) as f:
         buff3line = deque()


### PR DESCRIPTION
Closes #103 
Identified an issue when subcatchments are named numerically (e.g. 1, 2, 3, 4), the polygon dataframe index is automatically converted to integer from string, so when coords column is assigned is not updated.

See example_1 model input.

Closes #102 
Add flexibility in columns depending on swmm version number.
