### PR TITLE
cast indices of dataframes to strings in lower-level functions 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ _build/
 *.chi
 *.~inp
 *.thm
+
+# env
+venv/

--- a/swmmio/tests/test_dataframes.py
+++ b/swmmio/tests/test_dataframes.py
@@ -72,7 +72,7 @@ def test_node_dataframe_from_rpt(test_model_02):
     assert (depth_summ.loc['4', 'MaxNodeDepth'] == 0.87)
 
     # need to ensure indices are strings always
-    assert (flood_summ.loc[5, 'TotalFloodVol'] == 0)
+    assert (flood_summ.loc['5', 'TotalFloodVol'] == 0)
 
 
 def test_conduits_dataframe(test_model_01):

--- a/swmmio/tests/test_model_elements.py
+++ b/swmmio/tests/test_model_elements.py
@@ -153,3 +153,12 @@ def test_example_1():
     swmm_version = model_b.rpt.swmm_version 
     assert(swmm_version['patch'] == 13)
     elem_dict = {element: model_b.__getattribute__(element).geojson for element in element_types}
+
+    subs = model.subcatchments.dataframe
+    assert subs['TotalInfil'].sum() == pytest.approx(12.59, rel=0.001)
+    assert subs['TotalRunoffMG'].sum() == pytest.approx(2.05, rel=0.001)
+
+    # access lower level api
+    peak_runoff = model.rpt.subcatchment_runoff_summary['PeakRunoff']
+    assert peak_runoff.values == pytest.approx([4.66, 4.52, 2.45, 2.45, 6.56, 1.5, 0.79, 1.33], rel=0.001)
+    assert peak_runoff.values == pytest.approx(subs['PeakRunoff'].values, rel=0.001)

--- a/swmmio/utils/dataframes.py
+++ b/swmmio/utils/dataframes.py
@@ -90,6 +90,9 @@ def dataframe_from_rpt(rpt_path, section, element_id=None):
     df = pd.read_csv(StringIO(s), header=None, delim_whitespace=True, skiprows=[0],
                      index_col=0, names=cols)
 
+    # confirm index name is string
+    df = df.rename(index=str)
+
     return df
 
 
@@ -139,6 +142,8 @@ def dataframe_from_inp(inp_path, section, additional_cols=None, quote_replace=' 
             print(f'failed to parse {section} with cols: {cols}. head:\n{s[:500]}')
             raise
 
+    # confirm index name is string
+    df = df.rename(index=str)
     return df
 
 


### PR DESCRIPTION
This casts the indices of the dataframes to strings inside of `utils.dataframes.dataframe_from_inp` and `utils.dataframes.dataframe_from_rpt` to ensure that data can be merged along a common index inside of `swmmio.elements.ModelSection` 


Closes #106 