### PR TITLE
Read/write timeseries section of inp

### DIFF
--- a/swmmio/core.py
+++ b/swmmio/core.py
@@ -497,6 +497,7 @@ class inp(SWMMIOFile):
         self._inp_section_details = None
         self._inflows_df = None
         self._curves_df = None
+        self._timeseries_df = None
 
         SWMMIOFile.__init__(self, file_path)  # run the superclass init
 
@@ -518,7 +519,8 @@ class inp(SWMMIOFile):
             '[CURVES]',
             '[COORDINATES]',
             '[INFLOWS]',
-            '[Polygons]'
+            '[Polygons]',
+            '[TIMESERIES]'
         ]
 
     def save(self, target_path=None):
@@ -942,6 +944,21 @@ class inp(SWMMIOFile):
         """Set inp.curves DataFrame."""
         self._curves_df = df
 
+    @property
+    def timeseries(self):
+        """
+        get/set timeseries section of model
+        :return: multi-index dataframe of model curves
+        """
+        if self._timeseries_df is not None:
+            return self._timeseries_df
+        self._timeseries_df = create_dataframe_multi_index(self.path, '[TIMESERIES]')
+        return self._timeseries_df
+
+    @timeseries.setter
+    def timeseries(self, df):
+        """Set inp.timeseries DataFrame."""
+        self._timeseries_df = df
 
 def drop_invalid_model_elements(inp):
     """

--- a/swmmio/core.py
+++ b/swmmio/core.py
@@ -450,7 +450,7 @@ class rpt(SWMMIOFile):
         SWMMIOFile.__init__(self, filePath)
 
         meta_data = get_rpt_metadata(filePath)
-                
+
         self.swmm_version = meta_data['swmm_version']
         self.simulationStart = meta_data['simulation_start']
         self.simulationEnd = meta_data['simulation_end']
@@ -906,8 +906,8 @@ class inp(SWMMIOFile):
         return self._inflows_df
 
     @inflows.setter
-    def polygons(self, df):
-        """Set inp.polygons DataFrame."""
+    def inflows(self, df):
+        """Set inp.inflows DataFrame."""
         self._inflows_df = df
 
     @property
@@ -924,7 +924,7 @@ class inp(SWMMIOFile):
     @polygons.setter
     def polygons(self, df):
         """Set inp.polygons DataFrame."""
-        self._curves_df = df
+        self._polygons_df = df
 
     @property
     def curves(self):
@@ -939,7 +939,7 @@ class inp(SWMMIOFile):
 
     @curves.setter
     def curves(self, df):
-        """Set inp.polygons DataFrame."""
+        """Set inp.curves DataFrame."""
         self._curves_df = df
 
 

--- a/swmmio/defs/inp_sections.yml
+++ b/swmmio/defs/inp_sections.yml
@@ -51,7 +51,7 @@ inp_file_objects:
   XSECTIONS: [Link, Shape, Geom1, Geom2, Geom3, Geom4, Barrels, XX]
   INFLOWS: [Node, Constituent, Time Series, Type, Mfactor, Sfactor, Baseline, Pattern]
 
-
+  TIMESERIES: [Name, Date, Time, Value]
   COORDINATES: [Name, X, Y]
   VERTICES: [Name, X, Y]
   Polygons: [Name, X, Y]
@@ -61,6 +61,7 @@ inp_file_objects:
   TAGS: [ElementType, Name, Tag]
   ADJUSTMENTS: [blob]
   CURVES: [Name, Type, X-Value, Y-Value]
+
 
 
 inp_section_tags:

--- a/swmmio/defs/sectionheaders.py
+++ b/swmmio/defs/sectionheaders.py
@@ -28,7 +28,7 @@ inp_header_dict = {
     '[TAGS]':'ElementType Name Tag',
     '[MAP]': 'x1 y1 x2 y2',
     '[CURVES]': 'Name Type X-Value Y-Value',
-    #'[TIMESERIES]':'Name Date Time Value'
+    '[TIMESERIES]': 'Name Date Time Value'
 }
 
 

--- a/swmmio/tests/data/model_full_features_network.inp
+++ b/swmmio/tests/data/model_full_features_network.inp
@@ -235,6 +235,7 @@ SCS_24h_Type_I_1in            23:15      0.0185
 SCS_24h_Type_I_1in            23:30      0.0185    
 SCS_24h_Type_I_1in            23:45      0.0185    
 SCS_24h_Type_I_1in            24:00      0         
+TS2            FILE                "C:\Rotations\R3 - Vue\Quasi2D\2005_Pure2D\inflow_timeseries.txt"
 
 [REPORT]
 ;;Reporting Options

--- a/swmmio/tests/test_model_elements.py
+++ b/swmmio/tests/test_model_elements.py
@@ -146,11 +146,11 @@ def test_example_1():
     elem_dict = {element: model.__getattribute__(element).geojson for element in element_types}
     swmm_version = model.rpt.swmm_version
     assert(swmm_version['major'] == 5)
-    assert(swmm_version['minor'] == 1)  
+    assert(swmm_version['minor'] == 1)
     assert(swmm_version['patch'] == 12)
 
     model_b = swmmio.Model(MODEL_EX_1B)
-    swmm_version = model_b.rpt.swmm_version 
+    swmm_version = model_b.rpt.swmm_version
     assert(swmm_version['patch'] == 13)
     elem_dict = {element: model_b.__getattribute__(element).geojson for element in element_types}
 
@@ -162,3 +162,9 @@ def test_example_1():
     peak_runoff = model.rpt.subcatchment_runoff_summary['PeakRunoff']
     assert peak_runoff.values == pytest.approx([4.66, 4.52, 2.45, 2.45, 6.56, 1.5, 0.79, 1.33], rel=0.001)
     assert peak_runoff.values == pytest.approx(subs['PeakRunoff'].values, rel=0.001)
+
+def test_get_set_timeseries(test_model_01):
+
+    ts = test_model_01.inp.timeseries
+
+    print (ts)

--- a/swmmio/tests/test_model_elements.py
+++ b/swmmio/tests/test_model_elements.py
@@ -163,8 +163,11 @@ def test_example_1():
     assert peak_runoff.values == pytest.approx([4.66, 4.52, 2.45, 2.45, 6.56, 1.5, 0.79, 1.33], rel=0.001)
     assert peak_runoff.values == pytest.approx(subs['PeakRunoff'].values, rel=0.001)
 
-def test_get_set_timeseries(test_model_01):
+def test_get_set_timeseries(test_model_02):
 
-    ts = test_model_01.inp.timeseries
-
+    ts = test_model_02.inp.timeseries
+    assert(all(ts.columns == ['Date', 'Time', 'Value']))
+    assert(ts.loc['TS2'].Date == 'FILE')
+    assert('"' in ts.loc['TS2'].Value)
+    assert(ts.Value.isnull().sum() == 0)
     print (ts)

--- a/swmmio/utils/dataframes.py
+++ b/swmmio/utils/dataframes.py
@@ -6,7 +6,7 @@ from swmmio.utils.text import (extract_section_of_file, get_inp_sections_details
 from io import StringIO
 import warnings
 import pandas as pd
-
+import re
 
 def dataframe_from_bi(bi_path, section='[CONDUITS]'):
     """
@@ -41,14 +41,23 @@ def create_dataframe_multi_index(inp_path, section='CURVES'):
     f = StringIO(s)
     data = []
     for line in f.readlines():
-        items = line.strip().split()
-        if len(items) == 3:
-            items = [items[0], None, items[1], items[2]]
+        if "FILE" in line:
+            filename = re.findall(r'"([^"]*)"', line)[0]
+            items = line.strip().split()[:2]
+            items = [items[0], items[1], None, '"{}"'.format(filename)]
+        else:
+            items = line.strip().split()
+            if len(items) == 3:
+                items = [items[0], None, items[1], items[2]]
         if len(items) == 4:
             data.append(items)
 
+
     df = pd.DataFrame(data=data, columns=cols)
-    df = df.set_index(['Name', 'Type'])
+    if sect == 'CURVES':
+        df = df.set_index(['Name', 'Type'])
+    elif sect == 'TIMESERIES':
+        df = df.set_index(['Name'])
 
     return df
 


### PR DESCRIPTION
#57 Addresses TIMESERIES section. Model object can now read timeseries section (direct data and file-pointers). `replace_inp_section` also works. Added a file-pointing timeseries into `model_full_features_network.inp` for testing.