### PR TITLE
Define `max_columns` option as a display option

### DIFF
--- a/swmmio/core.py
+++ b/swmmio/core.py
@@ -20,7 +20,7 @@ from swmmio.defs import INP_OBJECTS, INFILTRATION_COLS, RPT_OBJECTS, COMPOSITE_O
 from swmmio.utils.functions import trim_section_to_nodes
 from swmmio.utils.text import get_inp_sections_details, get_rpt_sections_details, get_rpt_metadata
 
-pd.set_option('max_columns', 5)
+pd.set_option('display.max_columns', 5)
 
 __all__ = ['Model', 'inp', 'rpt']
 


### PR DESCRIPTION
To overcome issue `pandas._config.config.OptionError: 'Pattern matched multiple keys'` in pandas 1.4.0, one need to specify display of render when defining the option.