### PR TITLE
specify mistune==0.8.4 to control m2r depency verssion

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,6 @@ networkx>=2.4
 pyyaml>=3.12
 recommonmark
 m2r
+mistune==0.8.4
 # Run dependencies
 pyproj>=3.0.0


### PR DESCRIPTION
Controls the `mistune` version (a dependency of m2r) to prevent the ` 'mistune' has no attribute 'BlockGrammar'` error

 
Closes #128 