### PR TITLE
generalize get_rpt_metadata for OWA SWMM

### DIFF
--- a/swmmio/__init__.py
+++ b/swmmio/__init__.py
@@ -6,7 +6,7 @@ from swmmio.utils.dataframes import dataframe_from_bi, dataframe_from_rpt, dataf
 '''Python SWMM Input/Output Tools'''
 
 
-VERSION_INFO = (0, 4, 11)
+VERSION_INFO = (0, 4, 12, 'dev0')
 __version__ = '.'.join(map(str, VERSION_INFO))
 __author__ = 'Adam Erispaha'
 __copyright__ = 'Copyright (c) 2016'

--- a/swmmio/tests/data/__init__.py
+++ b/swmmio/tests/data/__init__.py
@@ -31,6 +31,7 @@ MODEL_INFILTRAION_PARSE_FAILURE = os.path.join(DATA_PATH, 'model-with-infiltrati
 
 # test rpt paths
 RPT_FULL_FEATURES = os.path.join(DATA_PATH, 'model_full_features_network.rpt')
+OWA_RPT_EXAMPLE = os.path.join(DATA_PATH, 'owa-rpt-example.rpt')
 
 # version control test models
 MODEL_XSECTION_BASELINE = os.path.join(DATA_PATH, 'baseline_test.inp')

--- a/swmmio/tests/data/owa-rpt-example.rpt
+++ b/swmmio/tests/data/owa-rpt-example.rpt
@@ -1,0 +1,292 @@
+
+  OWA STORM WATER MANAGEMENT MODEL - VERSION v5.1.14 (OWA 2022-08-23)
+  --------------------------------------------------------------
+
+  Example 1 
+  
+  
+  *********************************************************
+  NOTE: The summary statistics displayed in this report are
+  based on results found at every computational time step,  
+  not just on results from each reporting time step.
+  *********************************************************
+  
+  ****************
+  Analysis Options
+  ****************
+  Flow Units ............... CFS
+  Process Models:
+    Rainfall/Runoff ........ YES
+    RDII ................... NO
+    Snowmelt ............... NO
+    Groundwater ............ NO
+    Flow Routing ........... YES
+    Ponding Allowed ........ NO
+    Water Quality .......... YES
+  Infiltration Method ...... HORTON
+  Flow Routing Method ...... KINWAVE
+  Starting Date ............ 01/01/1998 00:00:00
+  Ending Date .............. 01/02/1998 12:00:00
+  Antecedent Dry Days ...... 5.0
+  Report Time Step ......... 01:00:00
+  Wet Time Step ............ 00:15:00
+  Dry Time Step ............ 01:00:00
+  Routing Time Step ........ 60.00 sec
+  
+  
+  **************************        Volume         Depth
+  Runoff Quantity Continuity     acre-feet        inches
+  **************************     ---------       -------
+  Total Precipitation ......        15.679         2.650
+  Evaporation Loss .........         0.000         0.000
+  Infiltration Loss ........         9.346         1.580
+  Surface Runoff ...........         6.295         1.064
+  Final Storage ............         0.081         0.014
+  Continuity Error (%) .....        -0.272
+  
+  
+  **************************          Lead           TSS
+  Runoff Quality Continuity            lbs           lbs
+  **************************    ----------    ----------
+  Initial Buildup ..........         0.000      3433.036
+  Surface Buildup ..........         0.086       312.924
+  Wet Deposition ...........         0.000         0.000
+  Sweeping Removal .........         0.000         0.000
+  Infiltration Loss ........         0.000         0.000
+  BMP Removal ..............         0.000         0.000
+  Surface Runoff ...........         0.086       431.367
+  Remaining Buildup ........         0.000      3314.593
+  Continuity Error (%) .....         0.000         0.000
+  
+  
+  **************************        Volume        Volume
+  Flow Routing Continuity        acre-feet      10^6 gal
+  **************************     ---------     ---------
+  Dry Weather Inflow .......         0.000         0.000
+  Wet Weather Inflow .......         6.295         2.051
+  Groundwater Inflow .......         0.000         0.000
+  RDII Inflow ..............         0.000         0.000
+  External Inflow ..........         0.000         0.000
+  External Outflow .........         5.874         1.914
+  Flooding Loss ............         0.415         0.135
+  Evaporation Loss .........         0.000         0.000
+  Exfiltration Loss ........         0.000         0.000
+  Initial Stored Volume ....         0.000         0.000
+  Final Stored Volume ......         0.000         0.000
+  Continuity Error (%) .....         0.101
+  
+  
+  **************************          Lead           TSS
+  Quality Routing Continuity           lbs           lbs
+  **************************    ----------    ----------
+  Dry Weather Inflow .......         0.000         0.000
+  Wet Weather Inflow .......         0.086       431.367
+  Groundwater Inflow .......         0.000         0.000
+  RDII Inflow ..............         0.000         0.000
+  External Inflow ..........         0.000         0.000
+  External Outflow .........         0.082       409.791
+  Flooding Loss ............         0.004        22.239
+  Exfiltration Loss ........         0.000         0.000
+  Mass Reacted .............         0.000         0.000
+  Initial Stored Mass ......         0.000         0.000
+  Final Stored Mass ........         0.000         0.000
+  Continuity Error (%) .....        -0.154        -0.154
+  
+  
+  ********************************
+  Highest Flow Instability Indexes
+  ********************************
+  Link 15 (1)
+  
+  
+  *************************
+  Routing Time Step Summary
+  *************************
+  Minimum Time Step           :    60.00 sec
+  Average Time Step           :    60.00 sec
+  Maximum Time Step           :    60.00 sec
+  Percent in Steady State     :     0.00
+  Average Iterations per Step :     1.49
+  Percent Not Converging      :     0.00
+  
+  
+  ***************************
+  Subcatchment Runoff Summary
+  ***************************
+  
+  --------------------------------------------------------------------------------------------------------
+                            Total      Total      Total      Total      Total       Total     Peak  Runoff
+                           Precip      Runon       Evap      Infil     Runoff      Runoff   Runoff   Coeff
+  Subcatchment                 in         in         in         in         in    10^6 gal      CFS
+  --------------------------------------------------------------------------------------------------------
+  1                          2.65       0.00       0.00       1.16       1.48        0.40     4.66   0.559
+  2                          2.65       0.00       0.00       1.21       1.43        0.39     4.52   0.539
+  3                          2.65       0.00       0.00       1.16       1.49        0.20     2.45   0.561
+  4                          2.65       0.00       0.00       1.16       1.49        0.20     2.45   0.561
+  5                          2.65       0.00       0.00       1.24       1.40        0.57     6.56   0.528
+  6                          2.65       0.00       0.00       2.27       0.38        0.12     1.50   0.143
+  7                          2.65       0.00       0.00       2.14       0.51        0.06     0.79   0.194
+  8                          2.65       0.00       0.00       2.25       0.40        0.11     1.33   0.150
+  
+  
+  ****************************
+  Subcatchment Washoff Summary
+  ****************************
+  
+  ------------------------------------------------
+                                Lead           TSS
+  Subcatchment                   lbs           lbs
+  ------------------------------------------------
+  1                            0.010        50.074
+  2                            0.018        90.586
+  3                            0.005        25.144
+  4                            0.009        46.097
+  5                            0.014        71.172
+  6                            0.013        65.843
+  7                            0.005        26.025
+  8                            0.011        56.427
+  ------------------------------------------------
+  System                       0.086       431.367
+  
+  
+  ******************
+  Node Depth Summary
+  ******************
+  
+  ---------------------------------------------------------------------------------
+                                 Average  Maximum  Maximum  Time of Max    Reported
+                                   Depth    Depth      HGL   Occurrence   Max Depth
+  Node                 Type         Feet     Feet     Feet  days hr:min        Feet
+  ---------------------------------------------------------------------------------
+  10                   JUNCTION     0.32     3.00   998.00     0  02:17        3.00
+  13                   JUNCTION     0.06     0.41   995.41     0  04:01        0.41
+  14                   JUNCTION     0.06     0.46   990.46     0  04:01        0.46
+  15                   JUNCTION     0.15     1.15   988.15     0  04:01        1.15
+  16                   JUNCTION     0.17     1.15   986.15     0  04:01        1.14
+  17                   JUNCTION     0.18     1.14   981.14     0  04:02        1.14
+  19                   JUNCTION     0.03     0.22  1010.22     0  04:01        0.22
+  20                   JUNCTION     0.03     0.22  1005.22     0  04:01        0.22
+  21                   JUNCTION     1.16     2.00   992.00     0  02:55        2.00
+  22                   JUNCTION     1.11     1.58   988.58     0  04:02        1.58
+  23                   JUNCTION     0.05     0.35   990.35     0  04:01        0.35
+  24                   JUNCTION     0.18     1.14   985.14     0  04:01        1.14
+  9                    JUNCTION     0.09     0.57  1000.57     0  04:01        0.57
+  18                   OUTFALL      0.17     1.07   976.07     0  04:02        1.06
+  
+  
+  *******************
+  Node Inflow Summary
+  *******************
+  
+  -------------------------------------------------------------------------------------------------
+                                  Maximum  Maximum                  Lateral       Total        Flow
+                                  Lateral    Total  Time of Max      Inflow      Inflow     Balance
+                                   Inflow   Inflow   Occurrence      Volume      Volume       Error
+  Node                 Type           CFS      CFS  days hr:min    10^6 gal    10^6 gal     Percent
+  -------------------------------------------------------------------------------------------------
+  10                   JUNCTION      4.52     9.17     0  04:01       0.388        0.79      -0.000
+  13                   JUNCTION      2.45     2.45     0  04:01       0.202       0.202       0.000
+  14                   JUNCTION      0.00     2.44     0  04:01           0       0.202       0.000
+  15                   JUNCTION      6.56     9.00     0  04:01        0.57       0.771       0.000
+  16                   JUNCTION      0.00    16.83     0  04:01           0        1.69       0.000
+  17                   JUNCTION      0.00    18.31     0  04:02           0        1.81       0.000
+  19                   JUNCTION      0.79     0.79     0  04:01      0.0558      0.0558       0.000
+  20                   JUNCTION      0.00     0.79     0  04:01           0      0.0558       0.000
+  21                   JUNCTION      0.00     5.42     0  04:02           0       0.714       0.000
+  22                   JUNCTION      2.45     7.86     0  04:01       0.202       0.915       0.000
+  23                   JUNCTION      1.50     1.50     0  04:01       0.124       0.124       0.000
+  24                   JUNCTION      0.00    18.31     0  04:01           0        1.81       0.000
+  9                    JUNCTION      4.66     4.66     0  04:01       0.402       0.402       0.000
+  18                   OUTFALL       1.33    19.58     0  04:01       0.108        1.91       0.000
+  
+  
+  *********************
+  Node Flooding Summary
+  *********************
+  
+  Flooding refers to all water that overflows a node, whether it ponds or not.
+  --------------------------------------------------------------------------
+                                                             Total   Maximum
+                                 Maximum   Time of Max       Flood    Ponded
+                        Hours       Rate    Occurrence      Volume    Volume
+  Node                 Flooded       CFS   days hr:min    10^6 gal  1000 ft3
+  --------------------------------------------------------------------------
+  10                      2.82      4.53      0  04:01       0.135     0.000
+  
+  
+  ***********************
+  Outfall Loading Summary
+  ***********************
+  
+  ---------------------------------------------------------------------------------------
+                         Flow       Avg       Max       Total         Total         Total
+                         Freq      Flow      Flow      Volume          Lead           TSS
+  Outfall Node           Pcnt       CFS       CFS    10^6 gal           lbs           lbs
+  ---------------------------------------------------------------------------------------
+  18                    72.87      2.71     19.58       1.914         0.082       409.791
+  ---------------------------------------------------------------------------------------
+  System                72.87      2.71     19.58       1.914         0.082       409.791
+  
+  
+  ********************
+  Link Flow Summary
+  ********************
+  
+  -----------------------------------------------------------------------------
+                                 Maximum  Time of Max   Maximum    Max/    Max/
+                                  |Flow|   Occurrence   |Veloc|    Full    Full
+  Link                 Type          CFS  days hr:min    ft/sec    Flow   Depth
+  -----------------------------------------------------------------------------
+  1                    CONDUIT      4.65     0  04:01      7.60    0.30    0.38
+  10                   CONDUIT     18.28     0  04:02     10.75    0.56    0.53
+  11                   CONDUIT      2.44     0  04:01      6.36    0.16    0.27
+  12                   CONDUIT      2.44     0  04:02      5.30    0.21    0.31
+  13                   CONDUIT      8.98     0  04:01      6.24    0.93    0.76
+  14                   CONDUIT      1.49     0  04:02      6.12    0.26    0.35
+  15                   CONDUIT     16.82     0  04:01      9.67    0.57    0.54
+  16                   CONDUIT     18.31     0  04:02      9.87    0.62    0.57
+  4                    CONDUIT      0.79     0  04:01      6.10    0.11    0.22
+  5                    CONDUIT      0.79     0  04:02      9.00    0.06    0.17
+  6                    CONDUIT      4.93     0  02:53      7.01    1.06    1.00
+  7                    CONDUIT      5.42     0  04:02      7.19    0.18    0.29
+  8                    CONDUIT      7.85     0  04:01      6.84    0.33    0.39
+  
+  
+  *************************
+  Conduit Surcharge Summary
+  *************************
+  
+  ----------------------------------------------------------------------------
+                                                           Hours        Hours 
+                         --------- Hours Full --------   Above Full   Capacity
+  Conduit                Both Ends  Upstream  Dnstream   Normal Flow   Limited
+  ----------------------------------------------------------------------------
+  6                           2.80      2.80      2.80      2.80         2.80
+  
+  
+  ***************************
+  Link Pollutant Load Summary
+  ***************************
+  
+  ------------------------------------------------
+                                Lead           TSS
+  Link                           lbs           lbs
+  ------------------------------------------------
+  1                            0.010        50.061
+  10                           0.071       353.364
+  11                           0.005        25.127
+  12                           0.005        25.112
+  13                           0.019        96.264
+  14                           0.013        65.740
+  15                           0.058       287.513
+  16                           0.071       353.281
+  4                            0.005        25.990
+  5                            0.005        25.983
+  6                            0.024       119.073
+  7                            0.029       145.055
+  8                            0.038       191.152
+  
+
+  Analysis begun on:  Thu Sep 24 10:19:56 2020
+  Analysis ended on:  Thu Sep 24 10:19:56 2020
+  Total elapsed time: < 1 sec

--- a/swmmio/tests/test_functions.py
+++ b/swmmio/tests/test_functions.py
@@ -1,6 +1,7 @@
 import swmmio
-from swmmio.tests.data import MODEL_FULL_FEATURES__NET_PATH
+from swmmio.tests.data import MODEL_FULL_FEATURES__NET_PATH, OWA_RPT_EXAMPLE, RPT_FULL_FEATURES
 from swmmio.utils.functions import format_inp_section_header
+from swmmio.utils.text import get_rpt_metadata
 
 
 def test_format_inp_section_header():
@@ -20,6 +21,16 @@ def test_format_inp_section_header():
     header_string = 'pumps'
     header_string = format_inp_section_header(header_string)
     assert (header_string == '[PUMPS]')
+
+
+def test_get_rpt_metadata_owa_swmm():
+    meta = get_rpt_metadata(OWA_RPT_EXAMPLE)
+    assert meta['swmm_version'] == {'major': 5, 'minor': 1, 'patch': 14}
+
+
+def test_get_rpt_metadata_epa_swmm():
+    meta = get_rpt_metadata(RPT_FULL_FEATURES)
+    assert meta['swmm_version'] == {'major': 5, 'minor': 0, 'patch': 22}
 
 
 def test_model_to_networkx():

--- a/swmmio/utils/text.py
+++ b/swmmio/utils/text.py
@@ -136,7 +136,7 @@ def get_rpt_metadata(file_path):
                 simulation_start = line.split(".. ")[1].replace("\n", "")
             if "Ending Date" in line:
                 simulation_end = line.split(".. ")[1].replace("\n", "")
-            if "EPA STORM WATER MANAGEMENT MODEL - VERSION" in line:
+            if "STORM WATER MANAGEMENT MODEL - VERSION" in line:
                 version = re.search(r"\d+.\d+.\d+", line)
                 if version is not None:
                     version = version.group(0).split('.')


### PR DESCRIPTION
Adds unit tests for `get_rpt_metadata` and generalizes the search string use to find the swmm version in RPT files.

Closes #142 